### PR TITLE
1958 species in returns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-cron==0.4.6
 django-dynamic-fixture>=1.9.0
 openpyxl==2.3.5
 datapackage>=0.6.1
-jsontableschema>=0.6.3
+jsontableschema==0.6.5
 python-dateutil==2.5.3
 py4j==0.10.2.1
 djangorestframework==3.4.0

--- a/wildlifelicensing/apps/returns/static/wl/js/return_table.js
+++ b/wildlifelicensing/apps/returns/static/wl/js/return_table.js
@@ -52,10 +52,10 @@ define([
         var $species_fields = $parent.find('input[data-species]');
         if ($species_fields.length > 0) {
             $species_fields.each(function () {
-                var $node = $(this),
-                    speciesType = $node.attr('data-species'),
+                var $field = $(this),
+                    speciesType = $field.attr('data-species'),
                     value;
-                $node.typeahead({
+                $field.typeahead({
                     minLength: 2,
                     items: 'all',
                     source: function (query, process) {
@@ -64,10 +64,10 @@ define([
                         });
                     }
                 });
-                value = $node.val();
+                value = $field.val();
                 if (value) {
                     // already some data. We try to validate.
-                    validateSpeciesField($node, speciesType);
+                    validateSpeciesField($field, speciesType);
                 }
             });
         }

--- a/wildlifelicensing/apps/returns/static/wl/js/return_table.js
+++ b/wildlifelicensing/apps/returns/static/wl/js/return_table.js
@@ -34,6 +34,20 @@ define([
         }
     }
 
+    function validateSpeciesField($field, speciesType) {
+        // Rules: if only one species is returned from the api we consider the name to be valid.
+        // Trick: the species can be recorded as: species_name (common name) in this case the search will fail
+        // (species_name or common name but not both). We get rid of anything in parenthesis.
+        var value = $field.val();
+        if (value) {
+            value = value.replace(/\s?\(.*\)/, '');
+            querySpecies(speciesType, value.trim(), function (data) {
+                var valid = data && data.length === 1;
+                setSpeciesValid($field, valid);
+            });
+        }
+    }
+
     function initSpeciesFields($parent) {
         var $species_fields = $parent.find('input[data-species]');
         if ($species_fields.length > 0) {
@@ -42,7 +56,7 @@ define([
                     speciesType = $node.attr('data-species'),
                     value;
                 $node.typeahead({
-                    minLength: 3,
+                    minLength: 2,
                     items: 'all',
                     source: function (query, process) {
                         querySpecies(speciesType, query, function (data) {
@@ -53,11 +67,7 @@ define([
                 value = $node.val();
                 if (value) {
                     // already some data. We try to validate.
-                    // Rules: if only one species is returned from the api we consider the name to be valid.
-                    querySpecies(speciesType, value, function (data) {
-                        var valid = data && data.length === 1;
-                        setSpeciesValid($node, valid);
-                    });
+                    validateSpeciesField($node, speciesType);
                 }
             });
         }

--- a/wildlifelicensing/apps/returns/static/wl/js/return_table.js
+++ b/wildlifelicensing/apps/returns/static/wl/js/return_table.js
@@ -1,8 +1,37 @@
-define(['jQuery', 'datatables.net', 'datatables.bootstrap', 'datatables.datetime'], function ($) {
+define([
+    'jQuery',
+    'datatables.net',
+    'datatables.bootstrap',
+    'datatables.datetime',
+    'bootstrap-3-typeahead'
+], function ($) {
     "use strict";
 
+    function initSpeciesFields($parent) {
+        var $species_fields = $parent.find('input[data-species]');
+        if ($species_fields.length > 0) {
+            $species_fields.each(function () {
+                var $node = $(this),
+                    speciesType = $node.attr('data-species');
+                $node.typeahead({
+                    minLength: 3,
+                    items: 'all',
+                    source: function (query, process) {
+                        var url = '/taxonomy/species_name?search=' + query;
+                        if (speciesType) {
+                            url += '&type=' + speciesType;
+                        }
+                        return $.get(url, function (data) {
+                            return process(data);
+                        });
+                    }
+                });
+            });
+        }
+    }
+
     return {
-        initTables: function() {
+        initTables: function () {
             var $tables = $('.return-table'),
                 $curationForm = $('#curationForm');
 
@@ -13,7 +42,9 @@ define(['jQuery', 'datatables.net', 'datatables.bootstrap', 'datatables.datetime
                 info: false
             });
 
-            $('.add-return-row').click(function() {
+            initSpeciesFields($tables);
+
+            $('.add-return-row').click(function () {
                 var $tbody = $(this).parent().find('table').find('tbody'),
                     $row = $tbody.find('tr:first');
                 // clone the top row
@@ -25,14 +56,15 @@ define(['jQuery', 'datatables.net', 'datatables.bootstrap', 'datatables.datetime
 
                 // append cloned row
                 $tbody.append($rowCopy);
+                initSpeciesFields($rowCopy);
             });
 
-            $('#accept').click(function() {
+            $('#accept').click(function () {
                 $curationForm.append($('<input>').attr('name', 'accept').addClass('hidden'));
                 $curationForm.submit();
             });
 
-            $('#decline').click(function() {
+            $('#decline').click(function () {
                 $curationForm.append($('<input>').attr('name', 'decline').addClass('hidden'));
                 $curationForm.submit();
             });

--- a/wildlifelicensing/apps/returns/templates/wl/curate_return.html
+++ b/wildlifelicensing/apps/returns/templates/wl/curate_return.html
@@ -115,7 +115,7 @@
                                         <thead>
                                             <tr>
                                                 {% for header in table.headers %}
-                                                    <th>{{ header }}</th>
+                                                    <th>{{ header.title }}{% if header.required %} *{% endif %}</th>
                                                 {% endfor %}
                                             </tr>
                                         </thead>
@@ -123,10 +123,14 @@
                                             {% for row in table.data %}
                                                 <tr>
                                                     {% for header in table.headers %}
-                                                        {% with value=row|get_item:header|get_item:'value' error=row|get_item:header|get_item:'error' %}
+                                                        {% with value=row|get_item:header.title|get_item:'value' error=row|get_item:header.title|get_item:'error' %}
                                                             <td>
-                                                                <input name="{{ table.name }}::{{ header }}"
-                                                                       value="{{ value }}"/>
+                                                                <input name="{{ table.name }}::{{ header.title }}"
+                                                                       value="{{ value|default_if_none:"" }}"
+                                                                       {%  if header.species %}
+                                                                           data-species="{{ header.species }}"
+                                                                       {% endif %}
+                                                                />
                                                                 {% if error %}
                                                                     <div><span class="text-danger">{{ error }}</span>
                                                                     </div>

--- a/wildlifelicensing/apps/returns/templates/wl/enter_return.html
+++ b/wildlifelicensing/apps/returns/templates/wl/enter_return.html
@@ -19,6 +19,10 @@
 {% block requirements %}
     require(["{% static 'wl/js/return_table.js' %}"], function (returnTable) {
         returnTable.initTables();
+        // disable form submit by 'enter' key
+        $(document).on("keypress", "form", function(event) {
+             return event.keyCode != 13;
+        });
     });
 {% endblock %}
 

--- a/wildlifelicensing/apps/returns/templates/wl/enter_return.html
+++ b/wildlifelicensing/apps/returns/templates/wl/enter_return.html
@@ -18,7 +18,7 @@
 
 {% block requirements %}
     require(["{% static 'wl/js/return_table.js' %}"], function (returnTable) {
-    returnTable.initTables();
+        returnTable.initTables();
     });
 {% endblock %}
 
@@ -120,7 +120,11 @@
                                                     {% with value=row|get_item:header.title|get_item:'value' error=row|get_item:header.title|get_item:'error' %}
                                                         <td>
                                                             <input name="{{ table.name }}::{{ header.title }}"
-                                                                   value="{{ value|default_if_none:"" }}"/>
+                                                                   value="{{ value|default_if_none:"" }}"
+                                                                   {%  if header.species %}
+                                                                       data-species="{{ header.species }}"
+                                                                   {% endif %}
+                                                            />
                                                             {% if error %}
                                                                 <div><span class="text-danger">{{ error }}</span></div>
                                                             {% endif %}
@@ -134,7 +138,11 @@
                                             <tr>
                                                 {% for header in table.headers %}
                                                     <td>
-                                                        <input name="{{ table.name }}::{{ header.title }}"/>
+                                                        <input name="{{ table.name }}::{{ header.title }}"
+                                                               {%  if header.species %}
+                                                                   data-species="{{ header.species }}"
+                                                               {% endif %}
+                                                        />
                                                     </td>
                                                 {% endfor %}
                                             </tr>

--- a/wildlifelicensing/apps/returns/tests/helpers.py
+++ b/wildlifelicensing/apps/returns/tests/helpers.py
@@ -1,6 +1,105 @@
+import copy
 from datetime import date, timedelta
 
 from wildlifelicensing.apps.returns.models import Return, ReturnType
+
+
+def clone(descriptor):
+    return copy.deepcopy(descriptor)
+
+
+BASE_CONSTRAINTS = {
+    "required": False
+}
+
+NOT_REQUIRED_CONSTRAINTS = {
+    "required": False
+}
+
+REQUIRED_CONSTRAINTS = {
+    "required": True
+}
+
+BASE_FIELD = {
+    "name": "Name",
+    "tile": "Title",
+    "type": "string",
+    "format": "default",
+    "constraints": clone(BASE_CONSTRAINTS)
+}
+
+GENERIC_SCHEMA = {
+    "fields": [
+        clone(BASE_FIELD)
+    ]
+}
+
+GENERIC_DATA_PACKAGE = {
+    "name": "test",
+    "resources": [
+        {
+            "name": "test",
+            "format": "CSV",
+            "title": "test",
+            "bytes": 0,
+            "mediatype": "text/csv",
+            "path": "test.csv",
+            "schema": clone(GENERIC_SCHEMA)
+        }
+    ],
+    "title": "Test"
+}
+
+SPECIES_NAME_FIELD = {
+    "name": "Species Name",
+    "type": "string",
+    "format": "default",
+    "constraints": {
+        "required": True
+    },
+    "wl": {
+        "type": "species"
+    }
+}
+
+LAT_LONG_OBSERVATION_SCHEMA = {
+    "fields": [
+        {
+            "name": "Observation Date",
+            "type": "date",
+            "format": "any",
+            "constraints": {
+                "required": True,
+            }
+        },
+        {
+            "name": "Latitude",
+            "type": "number",
+            "format": "default",
+            "constraints": {
+                "required": True,
+                "minimum": -90.0,
+                "maximum": 90.0,
+            }
+        },
+        {
+            "name": "Longitude",
+            "type": "number",
+            "format": "default",
+            "constraints": {
+                "required": True,
+                "minimum": -180.0,
+                "maximum": 180.0,
+            }
+        },
+    ]
+}
+
+SPECIES_SCHEMA = clone(LAT_LONG_OBSERVATION_SCHEMA)
+SPECIES_SCHEMA['fields'].append(clone(SPECIES_NAME_FIELD))
+
+SPECIES_DATA_PACKAGE = clone(GENERIC_DATA_PACKAGE)
+SPECIES_DATA_PACKAGE['resources'][0]['schema'] = clone(SPECIES_SCHEMA)
 
 
 def get_or_create_return_type(licence_type):

--- a/wildlifelicensing/apps/returns/tests/test_schema.py
+++ b/wildlifelicensing/apps/returns/tests/test_schema.py
@@ -185,6 +185,11 @@ class TestSpeciesField(TestCase):
         self.assertFalse(sch.species_fields)
 
     def test_species_by_field_name(self):
+        """
+        A previous implementation supported species field detection by just the field name.
+        Not anymore
+        :return:
+        """
         names = ['species name', 'Species Name', 'SPECIES_NAME', 'species_Name']
         for name in names:
             descriptor = clone(helpers.GENERIC_SCHEMA)
@@ -196,8 +201,7 @@ class TestSpeciesField(TestCase):
             field['name'] = name
             descriptor['fields'].append(field)
             sch = Schema(descriptor)
-            self.assertEqual(1, len(sch.species_fields))
-            self.assertEquals(name, sch.species_fields[0].name)
+            self.assertEqual(0, len(sch.species_fields))
 
     def test_species_by_wl_tag(self):
         # adding a wl species tag to a field turns it into a species field (whatever its name)

--- a/wildlifelicensing/apps/returns/tests/test_schema.py
+++ b/wildlifelicensing/apps/returns/tests/test_schema.py
@@ -1,0 +1,215 @@
+import datetime
+
+from django.utils import six
+from django.test import TestCase
+
+from wildlifelicensing.apps.returns.tests import helpers
+from wildlifelicensing.apps.returns.tests.helpers import BASE_CONSTRAINTS, clone, BASE_FIELD, REQUIRED_CONSTRAINTS
+from wildlifelicensing.apps.returns.utils_schema import SchemaConstraints, FieldSchemaError, SchemaField, Schema
+
+
+class TestSchemaConstraints(TestCase):
+    def test_none_or_empty(self):
+        """
+        None or empty is accepted
+        """
+        self.assertEquals({}, SchemaConstraints(None).data)
+        self.assertEquals({}, SchemaConstraints({}).data)
+
+    def test_required_property(self):
+        # no constraints -> require = False
+        self.assertFalse(SchemaConstraints(None).required)
+        cts = clone(BASE_CONSTRAINTS)
+        self.assertFalse(cts['required'])
+        self.assertFalse(SchemaConstraints(cts).required)
+
+        cts = clone(BASE_CONSTRAINTS)
+        cts['required'] = True
+        self.assertTrue(cts['required'])
+        self.assertTrue(SchemaConstraints(cts).required)
+
+    def test_get_method(self):
+        """
+        test that the SchemaField has the dict-like get('key', default)
+        """
+        cts = clone(BASE_CONSTRAINTS)
+        sch = SchemaConstraints(cts)
+        self.assertTrue(hasattr(sch, 'get'))
+        self.assertEquals(cts.get('required'), sch.get('required'))
+        self.assertEquals(cts.get('constraints'), sch.get('constraints'))
+        self.assertEquals(None, sch.get('bad_keys'))
+        self.assertEquals('default', sch.get('bad_keys', 'default'))
+
+
+class TestSchemaField(TestCase):
+    def setUp(self):
+        self.base_field = clone(BASE_FIELD)
+
+    def test_name_mandatory(self):
+        """
+        A schema field without name should throw an exception
+        """
+        field = self.base_field
+        del field['name']
+        with self.assertRaises(FieldSchemaError):
+            SchemaField(field)
+        # no blank
+        field = self.base_field
+        field['name'] = ''
+        with self.assertRaises(FieldSchemaError):
+            SchemaField(field)
+
+    def test_get_method(self):
+        """
+        test that the SchemaField has the dict-like get('key', default)
+        """
+        field = self.base_field
+        sch = SchemaField(field)
+        self.assertTrue(hasattr(sch, 'get'))
+        self.assertEquals(field.get('Name'), sch.get('Name'))
+        self.assertEquals(field.get('constraints'), sch.get('constraints'))
+        self.assertEquals(None, sch.get('bad_keys'))
+        self.assertEquals('default', sch.get('bad_keys', 'default'))
+
+    def test_column_name(self):
+        """
+        'column_name' is a property that is equal to name
+        """
+        field = self.base_field
+        sch = SchemaField(field)
+        self.assertEquals(sch.name, sch.column_name)
+        self.assertNotEqual(sch.column_name, sch.title)
+
+    def test_constraints(self):
+        """
+        test that the constraints property returned a SchemaConstraints
+        """
+        self.assertIsInstance(SchemaField(BASE_FIELD).constraints, SchemaConstraints)
+
+
+class TestSchemaFieldCast(TestCase):
+    def setUp(self):
+        self.base_field_descriptor = clone(BASE_FIELD)
+
+    def test_boolean(self):
+        true_values = [True, 'True', 'true', 'YES', 'yes', 'y', 't', '1', 1]
+        false_values = [False, 'FALSE', 'false', 'NO', 'no', 'n', 'f', '0', 0]
+        wrong_values = [2, 3, 'FLSE', 'flse', 'NON', 'oui', 'maybe', 'not sure']
+        descriptor = self.base_field_descriptor
+        descriptor['type'] = 'boolean'
+        # only 'default' format
+        descriptor['format'] = 'default'
+        f = SchemaField(descriptor)
+        for v in true_values:
+            self.assertTrue(f.cast(v))
+        for v in false_values:
+            self.assertFalse(f.cast(v))
+        for v in wrong_values:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
+    def test_date(self):
+        descriptor = clone(BASE_FIELD)
+        descriptor['type'] = 'date'
+        # 'default' format = ISO
+        descriptor['format'] = 'default'
+        f = SchemaField(descriptor)
+        valid_values = ['2016-07-29']
+        for v in valid_values:
+            date = f.cast(v)
+            self.assertIsInstance(date, datetime.date)
+            self.assertEqual(datetime.date(2016, 7, 29), date)
+        invalid_value = ['29/07/2016', '07/29/2016', '2016-07-29 15:28:37']
+        for v in invalid_value:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
+        # format='any'. 
+        # The main problem is to be sure that a dd/mm/yyyy is not interpreted as mm/dd/yyyy
+        descriptor['format'] = 'any'
+        f = SchemaField(descriptor)
+        valid_values = [
+            '2016-07-10',
+            '10/07/2016',
+            '10/07/16',
+            '2016-07-10 15:28:37',
+            '10-July-2016',
+            '10-JUlY-16',
+            '10-07-2016',
+            '10-07-16'
+        ]
+        expected_date = datetime.date(2016, 7, 10)
+        for v in valid_values:
+            date = f.cast(v)
+            self.assertIsInstance(date, datetime.date)
+            self.assertEqual(expected_date, date)
+        invalid_value = ['djskdj']
+        for v in invalid_value:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
+    def test_date_custom_format(self):
+        format_ = 'fmt:%d %b %y'  # ex 30 Nov 14
+        descriptor = {
+            'name': 'Date with fmt',
+            'type': 'date',
+            'format': format_
+        }
+        field = SchemaField(descriptor)
+        value = '30 Nov 14'
+        self.assertEqual(field.cast(value), datetime.date(2014, 11, 30))
+
+    def test_string(self):
+        # test that a blank string '' is not accepted when the field is required
+        null_values = ['null', 'none', 'nil', 'nan', '-', '']
+        desc = clone(BASE_FIELD)
+        desc['type'] = 'string'
+        desc['constraints'] = clone(REQUIRED_CONSTRAINTS)
+        f = SchemaField(desc)
+        for v in null_values:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
+        # test non unicode (python 2)
+        value = 'not unicode'
+        self.assertIsInstance(f.cast(value), six.text_type)
+        self.assertEqual(f.cast(value), value)
+
+
+class TestSpeciesField(TestCase):
+
+    def test_no_species(self):
+        descriptor = clone(helpers.GENERIC_SCHEMA)
+        sch = Schema(descriptor)
+        # no species field
+        self.assertFalse(sch.species_fields)
+
+    def test_species_by_field_name(self):
+        names = ['species name', 'Species Name', 'SPECIES_NAME', 'species_Name']
+        for name in names:
+            descriptor = clone(helpers.GENERIC_SCHEMA)
+            sch = Schema(descriptor)
+            # no species field
+            self.assertFalse(sch.species_fields)
+            # add a field named name
+            field = clone(BASE_FIELD)
+            field['name'] = name
+            descriptor['fields'].append(field)
+            sch = Schema(descriptor)
+            self.assertEqual(1, len(sch.species_fields))
+            self.assertEquals(name, sch.species_fields[0].name)
+
+    def test_species_by_wl_tag(self):
+        # adding a wl species tag to a field turns it into a species field (whatever its name)
+        descriptor = clone(helpers.GENERIC_SCHEMA)
+        sch = Schema(descriptor)
+        # no species field
+        self.assertFalse(sch.species_fields)
+        # tag
+        field = descriptor['fields'][0]
+        field['wl'] = {
+            'type': 'species'
+        }
+        sch = Schema(descriptor)
+        self.assertEqual(1, len(sch.species_fields))
+        self.assertEquals(field['name'], sch.species_fields[0].name)

--- a/wildlifelicensing/apps/returns/tests/test_schema.py
+++ b/wildlifelicensing/apps/returns/tests/test_schema.py
@@ -175,6 +175,37 @@ class TestSchemaFieldCast(TestCase):
         self.assertIsInstance(f.cast(value), six.text_type)
         self.assertEqual(f.cast(value), value)
 
+    def test_datetime_any(self):
+        """
+        test datetime field with 'any' format
+        :return:
+        """
+        descriptor = clone(BASE_FIELD)
+        descriptor['type'] = 'datetime'
+        # format='any'.
+        # The main problem is to be sure that a dd/mm/yyyy is not interpreted as mm/dd/yyyy
+        descriptor['format'] = 'any'
+        f = SchemaField(descriptor)
+        valid_values = [
+            '2016-07-10 13:55:00',
+            '10/07/2016 13:55',
+            '10/07/16 1:55 pm',
+            '2016-07-10 13:55:00',
+            '10-July-2016 13:55:00',
+            '10-JUlY-16 13:55:00',
+            '10-07-2016 13:55:00',
+            '10-07-16 13:55:00'
+        ]
+        expected_dt = datetime.datetime(2016, 7, 10, 13, 55, 00)
+        for v in valid_values:
+            dt = f.cast(v)
+            self.assertIsInstance(dt, datetime.datetime)
+            self.assertEqual(expected_dt, dt)
+        invalid_value = ['djskdj']
+        for v in invalid_value:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
 
 class TestSpeciesField(TestCase):
 

--- a/wildlifelicensing/apps/returns/utils_schema.py
+++ b/wildlifelicensing/apps/returns/utils_schema.py
@@ -185,7 +185,7 @@ class SchemaField:
 
     def cast(self, value):
         """
-        Returns o native Python object of the expected format. Will throw an exception
+        Returns a native Python object of the expected format. Will throw an exception
         if the value doesn't complies with any constraints. See for details:
         https://github.com/frictionlessdata/jsontableschema-py#types
         This method is mainly a helper for the validation_error

--- a/wildlifelicensing/apps/returns/utils_schema.py
+++ b/wildlifelicensing/apps/returns/utils_schema.py
@@ -1,5 +1,15 @@
+from __future__ import absolute_import, unicode_literals, print_function, division
+from future.utils import raise_with_traceback
+
+import json
+import re
+
+from dateutil.parser import parse as date_parse
+
 from jsontableschema.model import SchemaModel
 from jsontableschema import types
+from jsontableschema.exceptions import InvalidDateType
+
 from openpyxl import Workbook
 from openpyxl.styles import Font
 from openpyxl.writer.write_only import WriteOnlyCell
@@ -10,6 +20,81 @@ from wildlifelicensing.apps.main.excel import is_blank_value
 
 COLUMN_HEADER_FONT = Font(bold=True)
 
+YYYY_MM_DD_REGEX = re.compile(r'^\d{4}-\d{2}-\d{2}')
+
+
+class FieldSchemaError(Exception):
+    pass
+
+
+class DayFirstDateType(types.DateType):
+    """
+    Extend the jsontableschema DateType which use the mm/dd/yyyy date model for the 'any' format
+    to use dd/mm/yyyy.
+    """
+
+    def cast_any(self, value, fmt=None):
+        if isinstance(value, self.python_type):
+            return value
+        try:
+            # there's a 'bug' in dateutil.parser.parse (2.5.3)if you are using
+            # dayfirst=True. It will parse YYYY-MM-DD as YYYY-DD-MM !!
+            # https://github.com/dateutil/dateutil/issues/268
+            dayfirst = False if YYYY_MM_DD_REGEX.match(value) else True
+            return date_parse(value, dayfirst=dayfirst).date()
+        except (TypeError, ValueError) as e:
+            raise_with_traceback(InvalidDateType(e))
+
+
+class DayFirstDateTimeType(DayFirstDateType):
+    """
+    Extend the jsontableschema DateType which use the mm/dd/yyyy date model for the 'any' format
+    to use dd/mm/yyyy
+    """
+
+
+class NotBlankStringType(types.StringType):
+    """
+    The default StringType accepts empty string when required = True
+    """
+    null_values = ['null', 'none', 'nil', 'nan', '-', '']
+
+
+@python_2_unicode_compatible
+class WLSchema:
+    """
+    The utility class for the wildlife licensing data within a schema field
+    Use to tag a filed to be a species field
+    {
+      name: "...."
+      constraints: ....
+      wl: {
+                type: "species"
+              }
+    }
+    """
+    SPECIES_NAME_TYPE_NAME = 'species'
+
+    def __init__(self, data):
+        self.data = data or {}
+
+    # implement some dict like methods
+    def __getitem__(self, item):
+        return self.data.__getitem__(item)
+
+    def __str__(self):
+        return "WLSchema: {}".format(self.data)
+
+    @property
+    def type(self):
+        return self.get('type')
+
+    def get(self, k, d=None):
+        return self.data.get(k, d)
+
+    def is_species_name(self):
+        return self.type == self.SPECIES_NAME_TYPE_NAME
+
 
 @python_2_unicode_compatible
 class SchemaField:
@@ -19,37 +104,58 @@ class SchemaField:
     https://github.com/frictionlessdata/jsontableschema-py#types
     for validation.
     """
+    # For most of the type we use the jsontableschema ones
+    BASE_TYPE_MAP = SchemaModel._type_map()
+    # except for anything date.
+    BASE_TYPE_MAP['date'] = DayFirstDateType
+    BASE_TYPE_MAP['datetime'] = DayFirstDateTimeType
+    # and string
+    BASE_TYPE_MAP['string'] = NotBlankStringType
+
+    WL_TYPE_MAP = {
+    }
 
     def __init__(self, data):
         self.data = data
-        self.name = data['name']  # We want to throw an exception if there is no name
-        # use of jsontableschema.types to help constraint validation
-        self.type = SchemaModel._type_map()[data.get('type')](data)
+        self.name = self.data.get('name')
+        # We want to throw an exception if there is no name
+        if not self.name:
+            raise FieldSchemaError("A field without a name: {}".format(json.dumps(data)))
+        # wl specific
+        self.wl = WLSchema(self.data.get('wl'))
+        # set the type: wl type as precedence
+        type_class = self.WL_TYPE_MAP.get(self.wl.type) or self.BASE_TYPE_MAP.get(self.data.get('type'))
+        self.type = type_class(self.data)
+        self.constraints = SchemaConstraints(self.data.get('constraints', {}))
+
+    # implement some dict like methods
+    def __getitem__(self, item):
+        return self.data.__getitem__(item)
+
+    def get(self, k, d=None):
+        return self.data.get(k, d)
+
+    @property
+    def title(self):
+        return self.data.get('title')
 
     @property
     def column_name(self):
         return self.name
 
     @property
-    def constraints(self):
-        return self.data.get('constraints', {})
-
-    @property
     def required(self):
-        return self.constraints.get('required', False)
+        return self.constraints.required
 
     def cast(self, value):
         """
-        Returns a native Python object of the expected format. Will throw an exception
+        Returns o native Python object of the expected format. Will throw an exception
         if the value doesn't complies with any constraints. See for details:
         https://github.com/frictionlessdata/jsontableschema-py#types
         This method is mainly a helper for the validation_error
         :param value:
         :return:
         """
-        if is_blank_value(value):
-            # must do that because an empty string is considered as valid even if required by the StringType
-            value = None
         if isinstance(value, six.string_types) and not isinstance(value, six.text_type):
             # the StringType accepts only unicode
             value = six.u(value)
@@ -91,6 +197,26 @@ class SchemaField:
         return '{}'.format(self.name)
 
 
+class SchemaConstraints:
+    """
+    A helper class for a schema field constraints
+    """
+
+    def __init__(self, data):
+        self.data = data or {}
+
+    # implement some dict like methods
+    def __getitem__(self, item):
+        return self.data.__getitem__(item)
+
+    def get(self, k, d=None):
+        return self.data.get(k, d)
+
+    @property
+    def required(self):
+        return self.get('required', False)
+
+
 class Schema:
     """
     A utility class for schema.
@@ -99,8 +225,36 @@ class Schema:
     """
 
     def __init__(self, schema):
+        self.data = schema
         self.schema_model = SchemaModel(schema)
         self.fields = [SchemaField(f) for f in self.schema_model.fields]
+        self.species_fields = self.find_species_name_fields(self)
+
+    # implement some dict like methods
+    def __getitem__(self, item):
+        return self.data.__getitem__(item)
+
+    def get(self, k, d=None):
+        return self.data.get(k, d)
+
+    @staticmethod
+    def find_species_name_fields(schema):
+        """
+        Precedence Rules:
+        2- Look for wl.type = 'speciesName'
+        3- Look for a field with name in ['species name', 'species_name'] case insensitive
+        :param schema: a dict descriptor or a Schema instance
+        :return: an array of [SchemaField] or []
+        """
+        if not isinstance(schema, Schema):
+            schema = Schema(schema)
+        fields = [f for f in schema.fields if f.wl.is_species_name()]
+        if fields:
+            return fields
+        else:
+            # look for column name
+            names = ['species name', 'species_name']
+            return [field for field in schema.fields if field.name.lower() in names]
 
     @property
     def headers(self):


### PR DESCRIPTION
[#1958 Species in returns](https://kanboard.dpaw.wa.gov.au/?controller=task&action=show&task_id=1958&project_id=24)  
When a field is 'tagged' as a species field in the schema of the `ReturnType`: 
- the return form will provide a type-ahead feature similar to the species field in application.
- if the form is pre-filled with species values (like after a an xlsx upload or a curate form), it provides a basic validation. The species field text will turn green if the name is valid.

Note: see the comment in the kanboard ticket on how to 'tag' a species field in the `Return Type` schema.
