### PR TITLE
1960 return api security

### DIFF
--- a/wildlifelicensing/apps/main/fixtures/groups.json
+++ b/wildlifelicensing/apps/main/fixtures/groups.json
@@ -10,5 +10,11 @@
         "fields": {
             "name": "Assessors"
         }
+    },
+        {
+        "model": "auth.Group",
+        "fields": {
+            "name": "API"
+        }
     }
 ]

--- a/wildlifelicensing/apps/main/tests/helpers.py
+++ b/wildlifelicensing/apps/main/tests/helpers.py
@@ -126,7 +126,7 @@ def get_or_create_default_officer():
 def get_or_create_api_user():
     user, created = get_or_create_user(TestData.DEFAULT_API_USER['email'], TestData.DEFAULT_API_USER)
     if created:
-        add_to_group(user, 'Officers')
+        add_to_group(user, 'API')
     return user
 
 

--- a/wildlifelicensing/apps/main/tests/helpers.py
+++ b/wildlifelicensing/apps/main/tests/helpers.py
@@ -48,6 +48,12 @@ class TestData(object):
         'name': 'ass group',
         'email': 'assessor@test.com',
     }
+    DEFAULT_API_USER = {
+        'email': 'apir@test.com',
+        'first_name': 'api',
+        'last_name': 'user',
+        'dob': '1979-12-13',
+    }
 
 
 class SocialClient(Client):
@@ -112,6 +118,13 @@ def get_or_create_default_customer(include_default_profile=False):
 
 def get_or_create_default_officer():
     user, created = get_or_create_user(TestData.DEFAULT_OFFICER['email'], TestData.DEFAULT_OFFICER)
+    if created:
+        add_to_group(user, 'Officers')
+    return user
+
+
+def get_or_create_api_user():
+    user, created = get_or_create_user(TestData.DEFAULT_API_USER['email'], TestData.DEFAULT_API_USER)
     if created:
         add_to_group(user, 'Officers')
     return user

--- a/wildlifelicensing/apps/returns/api/mixins.py
+++ b/wildlifelicensing/apps/returns/api/mixins.py
@@ -1,0 +1,18 @@
+from django.contrib.auth.mixins import UserPassesTestMixin
+
+from wildlifelicensing.apps.main.helpers import belongs_to
+
+
+def is_api_user(user):
+    return belongs_to(user, 'API') or user.is_superuser
+
+
+class APIUserRequiredMixin(UserPassesTestMixin):
+    """
+    Mixin uses for API view.
+    """
+    # we don't want to be redirected to login page.
+    raise_exception = True
+
+    def test_func(self):
+        return is_api_user(self.request.user)

--- a/wildlifelicensing/apps/returns/api/views.py
+++ b/wildlifelicensing/apps/returns/api/views.py
@@ -13,7 +13,7 @@ from wildlifelicensing.apps.returns.utils_schema import Schema
 API_SESSION_TIMEOUT = 100 * 24 * 3600  # 100 days
 
 
-def set_session_timeout(request):
+def set_api_session_timeout(request):
     request.session.set_expiry(API_SESSION_TIMEOUT)
 
 
@@ -60,7 +60,7 @@ class ExplorerView(APIUserRequiredMixin, View):
             return_obj['resources'] = resources
             results.append(return_obj)
         # for API purpose, increase the session timeout
-        set_session_timeout(request)
+        set_api_session_timeout(request)
         return JsonResponse(results, json_dumps_params={'indent': 2}, safe=False)
 
 
@@ -96,5 +96,5 @@ class ReturnsDataView(APIUserRequiredMixin, View):
                 row.append(unicode(ret_row.data.get(field, '')))
             writer.writerow(row)
         # for API purpose, increase the session timeout
-        set_session_timeout(request)
+        set_api_session_timeout(request)
         return response

--- a/wildlifelicensing/apps/returns/tests/test_api.py
+++ b/wildlifelicensing/apps/returns/tests/test_api.py
@@ -1,5 +1,10 @@
 from django.test import TestCase
 from django.core.urlresolvers import reverse
+from rest_framework import status
+
+from wildlifelicensing.apps.returns.models import ReturnType
+from wildlifelicensing.apps.main.tests import helpers
+from wildlifelicensing.apps.returns.api.mixins import is_api_user
 
 
 class TestExplorerView(TestCase):
@@ -14,10 +19,85 @@ class TestExplorerView(TestCase):
 
     def test_authorisation(self):
         """
-        Only admin or API users
+        Only superuser or API users
         :return:
         """
+        url = reverse("wl_returns:api:explorer")
+        customer = helpers.get_or_create_default_customer()
+        officer = helpers.get_or_create_default_officer()
+        assessor = helpers.get_or_create_default_assessor()
+
+        api_user = helpers.get_or_create_api_user()
+        self.assertTrue(is_api_user(api_user))
+
+        admin = helpers.create_random_customer()
+        admin.is_superuser = True
+        admin.save()
+        self.assertTrue(is_api_user(admin))
+
+        client = helpers.SocialClient()
+        forbidden = [customer, officer, assessor]
+        for user in forbidden:
+            client.login(user.email)
+            self.assertEqual(client.get(url).status_code,
+                             status.HTTP_403_FORBIDDEN)
+            client.logout()
+
+        allowed = [admin, api_user]
+        for user in allowed:
+            client.login(user.email)
+            self.assertEqual(client.get(url).status_code,
+                             status.HTTP_200_OK)
+            client.logout()
 
 
 class TestDataView(TestCase):
-    pass
+    fixtures = [
+        'countries',
+        'groups',
+        'licences',
+        'conditions',
+        'default-conditions',
+        'returns'
+    ]
+
+    def setUp(self):
+        # should have at least on return type
+        self.return_type = ReturnType.objects.first()
+        self.assertIsNotNone(self.return_type)
+
+    def test_authorisation(self):
+        """
+        Only superuser or API users
+        :return:
+        """
+        url = reverse("wl_returns:api:data", kwargs={
+            'return_type_pk': self.return_type.pk,
+            'resource_number': 0
+        })
+        customer = helpers.get_or_create_default_customer()
+        officer = helpers.get_or_create_default_officer()
+        assessor = helpers.get_or_create_default_assessor()
+
+        api_user = helpers.get_or_create_api_user()
+        self.assertTrue(is_api_user(api_user))
+
+        admin = helpers.create_random_customer()
+        admin.is_superuser = True
+        admin.save()
+        self.assertTrue(is_api_user(admin))
+
+        client = helpers.SocialClient()
+        forbidden = [customer, officer, assessor]
+        for user in forbidden:
+            client.login(user.email)
+            self.assertEqual(client.get(url).status_code,
+                             status.HTTP_403_FORBIDDEN)
+            client.logout()
+
+        allowed = [admin, api_user]
+        for user in allowed:
+            client.login(user.email)
+            self.assertEqual(client.get(url).status_code,
+                             status.HTTP_200_OK)
+            client.logout()

--- a/wildlifelicensing/apps/returns/tests/test_api.py
+++ b/wildlifelicensing/apps/returns/tests/test_api.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+
+
+class TestExplorerView(TestCase):
+    fixtures = [
+        'countries',
+        'groups',
+        'licences',
+        'conditions',
+        'default-conditions',
+        'returns'
+    ]
+
+    def test_authorisation(self):
+        """
+        Only admin or API users
+        :return:
+        """
+
+
+class TestDataView(TestCase):
+    pass


### PR DESCRIPTION
[#1960 Add security on Return API](https://kanboard.dpaw.wa.gov.au/?controller=task&action=show&task_id=1960&project_id=24)  
As discussed the API does't implement any Authentication mechanism other than the sessionId
