### PR TITLE
Product codes with variants now seperate with space,

### DIFF
--- a/wildlifelicensing/apps/applications/templates/wl/emails/licence_issued.html
+++ b/wildlifelicensing/apps/applications/templates/wl/emails/licence_issued.html
@@ -18,7 +18,7 @@
     </p>
     <p></p>
     <p>
-        from Jim Sharp<br>
+        for Jim Sharp<br>
         DIRECTOR GENERAL
     </p>
     <p>

--- a/wildlifelicensing/apps/applications/templates/wl/emails/licence_issued.txt
+++ b/wildlifelicensing/apps/applications/templates/wl/emails/licence_issued.txt
@@ -17,7 +17,7 @@ Yours sincerely
 
 
 
-from Jim Sharp
+for Jim Sharp
 
 DIRECTOR GENERAL
 

--- a/wildlifelicensing/apps/applications/templates/wl/emails/renew_licence_notification.html
+++ b/wildlifelicensing/apps/applications/templates/wl/emails/renew_licence_notification.html
@@ -28,7 +28,7 @@
     </p>
     <p></p>
     <p>
-        from Jim Sharp<br>
+        for Jim Sharp<br>
         DIRECTOR GENERAL
     </p>
     <p>

--- a/wildlifelicensing/apps/applications/templates/wl/emails/renew_licence_notification.txt
+++ b/wildlifelicensing/apps/applications/templates/wl/emails/renew_licence_notification.txt
@@ -21,7 +21,7 @@ Yours sincerely
 
 
 
-from Jim Sharp
+for Jim Sharp
 
 DIRECTOR GENERAL
 

--- a/wildlifelicensing/apps/applications/views/entry.py
+++ b/wildlifelicensing/apps/applications/views/entry.py
@@ -196,6 +196,8 @@ class SelectLicenceTypeView(LoginRequiredMixin, TemplateView):
 
             application.licence_type = WildlifeLicenceType.objects.get(id=self.args[0])
 
+            application.data = None
+
             application.variants.clear()
 
             for index, variant_id in enumerate(request.GET.getlist('variants', [])):

--- a/wildlifelicensing/apps/main/pdf.py
+++ b/wildlifelicensing/apps/main/pdf.py
@@ -415,7 +415,7 @@ def _create_letter_signature():
     signature_elements = []
     signature_elements.append(Paragraph('Yours sincerely', styles['LetterLeft']))
     signature_elements.append(Spacer(1, SECTION_BUFFER_HEIGHT * 4))
-    signature_elements.append(Paragraph('from Jim Sharp', styles['LetterLeft']))
+    signature_elements.append(Paragraph('for Jim Sharp', styles['LetterLeft']))
     signature_elements.append(Paragraph('DIRECTOR GENERAL', styles['LetterLeft']))
     signature_elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
 

--- a/wildlifelicensing/apps/payments/utils.py
+++ b/wildlifelicensing/apps/payments/utils.py
@@ -35,7 +35,7 @@ def generate_product_code_variants(licence_type):
             return
 
         for variant in variant_group.variants.all():
-            variant_code = '{}_{}'.format(product_code, variant.product_code)
+            variant_code = '{} {}'.format(product_code, variant.product_code)
 
             __append_variant_codes(variant_code, variant_group.child, variant_codes)
 
@@ -50,8 +50,9 @@ def generate_product_code(application):
     product_code = application.licence_type.product_code
 
     if application.variants.exists():
-        product_code += '_' + '_'.join(application.variants.through.objects.filter(application=application).
-                                       order_by('order').values_list('variant__product_code', flat=True))
+        product_code = '{} {}'.format(product_code,
+                                      ' '.join(application.variants.through.objects.filter(application=application).
+                                               order_by('order').values_list('variant__product_code', flat=True)))
 
     return product_code
 


### PR DESCRIPTION
 changed 'from Jim Sharp' to 'for Jim Sharp'

Clear application data if selecting new licence type.
