### PR TITLE
2833 Discarded applications must not be deleted

### DIFF
--- a/wildlifelicensing/apps/applications/models.py
+++ b/wildlifelicensing/apps/applications/models.py
@@ -149,7 +149,7 @@ class Application(RevisionedMixin):
     @property
     def is_deletable(self):
         """
-        An application can be deleted only if it is a draft and it hasn't been lodge yet
+        An application can be deleted only if it is a draft and it hasn't been lodged yet
         :return:
         """
         return self.customer_status == 'draft' and not self.lodgement_number

--- a/wildlifelicensing/apps/applications/models.py
+++ b/wildlifelicensing/apps/applications/models.py
@@ -45,8 +45,6 @@ class Application(RevisionedMixin):
                                  ('declined', 'Declined'),
                                  ('discarded', 'Discarded'),
                                  )
-    # List of statuses from processing list above that allow a customer to discard an application
-    CUSTOMER_DISCARDABLE_STATE = ['awaiting_applicant_response']
 
     ID_CHECK_STATUS_CHOICES = (('not_checked', 'Not Checked'), ('awaiting_update', 'Awaiting Update'),
                                ('updated', 'Updated'), ('accepted', 'Accepted'))
@@ -138,6 +136,23 @@ class Application(RevisionedMixin):
         return self.licence_type.senior_applicable and \
             self.applicant.is_senior and \
             bool(self.applicant.senior_card)
+
+    @property
+    def is_discardable(self):
+        """
+        An application can be discarded by a customer if:
+        1 - It is a draft
+        2- or if the application has been pushed back to the user
+        """
+        return self.customer_status == 'draft' or self.processing_status == 'awaiting_applicant_response'
+
+    @property
+    def is_deletable(self):
+        """
+        An application can be deleted only if it is a draft and it hasn't been lodge yet
+        :return:
+        """
+        return self.customer_status == 'draft' and not self.lodgement_number
 
     def log_user_action(self, action, request):
         return ApplicationUserAction.log_action(self, action, request.user)

--- a/wildlifelicensing/apps/applications/templates/wl/entry/confirm_discard.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/confirm_discard.html
@@ -1,3 +1,6 @@
 {% extends 'wl/confirm_base.html' %}
-
+{% block confirm_message %}
+    <h3 class="text-center">You are about to discard an application.</h3>
+    <h3 class="text-center">Please confirm your action.</h3>
+{% endblock %}
 {% block confirm_btn_text %}Discard Application{% endblock %}

--- a/wildlifelicensing/apps/applications/tests/helpers.py
+++ b/wildlifelicensing/apps/applications/tests/helpers.py
@@ -79,6 +79,12 @@ def get_or_create_condition(code, defaults):
     return Condition.objects.get_or_create(code=code, defaults=defaults)[0]
 
 
+def set_application_session(client, application):
+    session = client.session
+    session['application_id'] = application.pk
+    session.save()
+
+
 class HelpersTest(TestCase):
     def test_create_profile(self):
         user = create_random_customer()

--- a/wildlifelicensing/apps/applications/tests/test_entry.py
+++ b/wildlifelicensing/apps/applications/tests/test_entry.py
@@ -1,17 +1,16 @@
 import os
 
-from django.core.urlresolvers import reverse
 from django.core.files import File
+from django.core.urlresolvers import reverse
 from django.test import TestCase, TransactionTestCase
 
 from ledger.accounts.models import EmailUser, Document, Address, Profile
-
-from wildlifelicensing.apps.main.models import WildlifeLicenceType
-from wildlifelicensing.apps.main.tests.helpers import SocialClient, get_or_create_default_customer, \
-    create_random_customer, is_login_page, clear_mailbox, is_client_authenticated, get_response_messages, \
-    has_response_error_messages, has_response_messages
 from wildlifelicensing.apps.applications.models import Application
 from wildlifelicensing.apps.applications.tests import helpers
+from wildlifelicensing.apps.main.models import WildlifeLicenceType
+from wildlifelicensing.apps.main.tests.helpers import SocialClient, get_or_create_default_customer, \
+    create_random_customer, is_login_page, clear_mailbox, is_client_authenticated, \
+    has_response_error_messages, has_response_messages
 
 TEST_ID_PATH = os.path.join('wildlifelicensing', 'apps', 'main', 'test_data', 'test_id.jpg')
 
@@ -166,12 +165,12 @@ class ApplicationEntryTestCase(TestCase):
         self.client.get(reverse('wl_applications:select_licence_type', args=(self.licence_type.pk,)))
 
         # create profiles
-        address1 = Address.objects.create(user=self.customer, line1='1 Test Street', locality='Test Suburb', 
+        address1 = Address.objects.create(user=self.customer, line1='1 Test Street', locality='Test Suburb',
                                           state='WA', postcode='0001')
         profile1 = Profile.objects.create(user=self.customer, name='Test Profile', email='test@testplace.net.au',
                                           institution='Test Institution', postal_address=address1)
 
-        address2 = Address.objects.create(user=self.customer, line1='2 Test Street', locality='Test Suburb', 
+        address2 = Address.objects.create(user=self.customer, line1='2 Test Street', locality='Test Suburb',
                                           state='WA', postcode='0001')
         profile2 = Profile.objects.create(user=self.customer, name='Test Profile 2', email='test@testplace.net.au',
                                           institution='Test Institution', postal_address=address2)
@@ -433,6 +432,11 @@ class ApplicationEntrySecurity(TransactionTestCase):
 
 class TestApplicationDiscardView(TestCase):
     """
+    Rules of discard:
+    If draft not submitted -> delete the app
+    otherwise -> flag as discarded
+    @see https://kanboard.dpaw.wa.gov.au/?controller=TaskViewController&action=show&task_id=2833&project_id=24
+
     External person must be able to discard application pushed back .
     @see https://kanboard.dpaw.wa.gov.au/?controller=TaskViewController&action=show&task_id=2743&project_id=24
     """
@@ -456,7 +460,7 @@ class TestApplicationDiscardView(TestCase):
         """
         # lodge application
         application = helpers.create_and_lodge_application(self.applicant)
-        self.assertNotIn(application.processing_status, Application.CUSTOMER_DISCARDABLE_STATE)
+        self.assertFalse(application.is_discardable)
 
         # try to discard with get or post
         previous_processing_status = application.processing_status
@@ -485,10 +489,10 @@ class TestApplicationDiscardView(TestCase):
         # the response should have an error message
         self.assertTrue(has_response_error_messages(resp))
 
-    def test_discard_happy_path(self):
+    def test_pushed_back_application_discarded_not_deleted(self):
         # lodge application
         application = helpers.create_and_lodge_application(self.applicant)
-        self.assertNotIn(application.processing_status, Application.CUSTOMER_DISCARDABLE_STATE)
+        self.assertFalse(application.is_discardable)
         # officer request amendment
         url = reverse('wl_applications:amendment_request')
         self.client.login(self.officer.email)
@@ -500,7 +504,9 @@ class TestApplicationDiscardView(TestCase):
         self.assertEquals(resp.status_code, 200)
         application.refresh_from_db()
         # application should now be discardable
-        self.assertIn(application.processing_status, Application.CUSTOMER_DISCARDABLE_STATE)
+        self.assertTrue(application.is_discardable)
+        # but not deletable
+        self.assertFalse(application.is_deletable)
 
         # discard
         self.client.logout()
@@ -515,6 +521,7 @@ class TestApplicationDiscardView(TestCase):
         self.assertEquals(resp.status_code, 200)
         # test that there's a cancel_url in the context of the response and an action_url that is set to the proper url
         self.assertTrue('cancel_url' in resp.context)
+        self.assertEqual(resp.context['cancel_url'], reverse('wl_dashboard:home'))
         self.assertTrue('action_url' in resp.context)
         self.assertEquals(resp.context['action_url'], url)
         application.refresh_from_db()
@@ -524,6 +531,7 @@ class TestApplicationDiscardView(TestCase):
         self.assertEqual(application.processing_status, previous_processing_status)
         self.assertEqual(application.customer_status, previous_customer_status)
 
+        # actual discard
         resp = self.client.post(url, data=None, follow=True)
         self.assertEquals(resp.status_code, 200)
         application.refresh_from_db()
@@ -533,3 +541,114 @@ class TestApplicationDiscardView(TestCase):
         self.assertTrue(has_response_messages(resp))
         self.assertFalse(has_response_error_messages(resp))
 
+    def test_not_submitted_draft_are_deleted(self):
+        """
+        This is the happy path and the only use case where the application can be deleted.
+        User create application, save as draft and delete it
+        """
+        self.client.login(self.applicant.email)
+        application = helpers.create_application(self.applicant)
+        self.assertEquals(application.customer_status, 'temp')
+        self.assertFalse(application.is_discardable)
+
+        # save application as a draft
+        helpers.set_application_session(self.client, application)
+        pk = self.client.session['application_id']
+        self.assertEqual(application.pk, pk)
+        url = reverse('wl_applications:enter_details')
+        data = {
+            'draft': 'draft'
+        }
+        resp = self.client.post(url, data=data, follow=True)
+        self.assertEqual(resp.status_code, 200)
+        application.refresh_from_db()
+        self.assertEquals(application.customer_status, 'draft')
+
+        # application should now be discardable
+        self.assertTrue(application.is_discardable)
+        # and deletable
+        self.assertTrue(application.is_deletable)
+
+        # discard
+        url = reverse('wl_applications:discard_application', args=[application.pk])
+        # the get should not delete but return a confirm page
+        previous_processing_status = application.processing_status
+        previous_customer_status = application.customer_status
+        resp = self.client.get(url, follow=True)
+        self.assertEquals(resp.status_code, 200)
+        # test that there's a cancel_url in the context of the response and an action_url that is set to the proper url
+        self.assertTrue('cancel_url' in resp.context)
+        self.assertEqual(resp.context['cancel_url'], reverse('wl_dashboard:home'))
+        self.assertTrue('action_url' in resp.context)
+        self.assertEquals(resp.context['action_url'], url)
+        # Application should not be deleted
+        application = Application.objects.filter(pk=application.pk).first()
+        self.assertIsNotNone(application)
+        # status should be unchanged
+        self.assertEqual(application.processing_status, previous_processing_status)
+        self.assertEqual(application.customer_status, previous_customer_status)
+
+        # actual discard
+        resp = self.client.post(url, data=None, follow=True)
+        self.assertEquals(resp.status_code, 200)
+        # Application should now be deleted
+        application = Application.objects.filter(pk=application.pk).first()
+        self.assertIsNone(application)
+
+    def test_submitted_draft_cannot_be_deleted(self):
+        """
+        Use case:
+        Applicant lodge an application.
+        Officer send it back to him with amendments requested
+        Applicant reopen it and save it as a draft
+        At this stage the user should not be able to delete it because it has already been lodged
+        """
+        # lodge application
+        application = helpers.create_and_lodge_application(self.applicant)
+        # application should not be discardable
+        self.assertFalse(application.is_discardable)
+        # and not deletable
+        self.assertFalse(application.is_deletable)
+
+        # officer request amendment
+        url = reverse('wl_applications:amendment_request')
+        self.client.login(self.officer.email)
+        resp = self.client.post(url, data={
+            'application': application.pk,
+            'officer': self.officer.pk,
+            'reason': 'missing_information'
+        })
+        self.assertEquals(resp.status_code, 200)
+        application.refresh_from_db()
+        self.client.logout()
+
+        self.client.login(self.applicant.email)
+        url = reverse('wl_applications:edit_application', args=[application.pk])
+        self.client.get(url, follow=True)
+        # save as draft
+        data = {
+            'draft': 'draft',
+            'data': application.data
+        }
+        url = reverse('wl_applications:enter_details')
+        resp = self.client.post(url, data, follow=True)
+        self.assertEqual(resp.status_code, 200)
+        application.refresh_from_db()
+        self.assertEqual(application.customer_status, 'draft')
+        # application should now be discardable
+        self.assertTrue(application.is_discardable)
+        # and not deletable
+        self.assertFalse(application.is_deletable)
+
+        # actual discard
+        url = reverse('wl_applications:discard_application', args=[application.pk])
+        resp = self.client.post(url, follow=True)
+        # application should not be deleted
+        application = Application.objects.filter(pk=application.pk).first()
+        self.assertIsNotNone(application)
+        # but in a discarded state
+        self.assertEqual(application.processing_status, 'discarded')
+        self.assertEqual(application.customer_status, 'discarded')
+        # there should be a message
+        self.assertTrue(has_response_messages(resp))
+        self.assertFalse(has_response_error_messages(resp))

--- a/wildlifelicensing/apps/applications/urls.py
+++ b/wildlifelicensing/apps/applications/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
 from wildlifelicensing.apps.applications.views.entry import NewApplicationView, SelectLicenceTypeView, \
-    CreateSelectCustomer, EditApplicationView, DeleteApplicationView, CheckIdentificationRequiredView, \
+    CreateSelectCustomer, EditApplicationView, CheckIdentificationRequiredView, \
     CreateSelectProfileView, EnterDetailsView, PreviewView, ApplicationCompleteView, RenewLicenceView, \
     AmendLicenceView, CheckSeniorCardView, DiscardApplicationView
 
@@ -25,7 +25,6 @@ urlpatterns = [
     url('^select-licence-type/([0-9]+)$', SelectLicenceTypeView.as_view(), name='select_licence_type'),
     url('^create-select-customer/$', CreateSelectCustomer.as_view(), name='create_select_customer'),
     url('^edit-application/([0-9]+)/$', EditApplicationView.as_view(), name='edit_application'),
-    url('^delete-application/([0-9]+)/$', DeleteApplicationView.as_view(), name='delete_application'),
     url('^discard-application/([0-9]+)/$', DiscardApplicationView.as_view(), name='discard_application'),
     url('^check-identification/$', CheckIdentificationRequiredView.as_view(), name='check_identification'),
     url('^check-senior-card/$', CheckSeniorCardView.as_view(), name='check_senior_card'),

--- a/wildlifelicensing/apps/dashboard/views/customer.py
+++ b/wildlifelicensing/apps/dashboard/views/customer.py
@@ -230,11 +230,9 @@ class DataTableApplicationCustomerView(base.DataTableApplicationBaseView):
     def render_action_column(obj):
         status = obj.customer_status
         if status == 'draft':
-            result = '<a href="{0}">{1}</a> / <a href="{2}">{3}</a>'.format(
+            result = '<a href="{0}">{1}</a>'.format(
                 reverse('wl_applications:edit_application', args=[obj.pk]),
-                'Continue',
-                reverse('wl_applications:delete_application', args=[obj.pk]),
-                'Discard'
+                'Continue'
             )
         elif status == 'amendment_required' or status == 'id_and_amendment_required':
             result = '<a href="{0}">{1}</a>'.format(
@@ -250,9 +248,8 @@ class DataTableApplicationCustomerView(base.DataTableApplicationBaseView):
                 reverse('wl_applications:view_application', args=[obj.pk]),
                 'View application (read-only)'
             )
-
-        # Add discard action (not delete)
-        if obj.processing_status in Application.CUSTOMER_DISCARDABLE_STATE and status != 'draft':
+        # Add discard action
+        if obj.is_discardable:
             result += ' / <a href="{}">{}</a>'.format(
                 reverse('wl_applications:discard_application', args=[obj.pk]),
                 'Discard'

--- a/wildlifelicensing/apps/dashboard/views/officer.py
+++ b/wildlifelicensing/apps/dashboard/views/officer.py
@@ -8,7 +8,8 @@ from django.http.response import HttpResponse
 
 from wildlifelicensing.apps.applications.models import Application
 from wildlifelicensing.apps.dashboard.views import base
-from wildlifelicensing.apps.dashboard.views.customer import DataTableReturnsCustomerView
+from wildlifelicensing.apps.dashboard.views.customer import DataTableReturnsCustomerView, \
+    DataTableApplicationCustomerView
 from wildlifelicensing.apps.main.helpers import get_all_officers
 from wildlifelicensing.apps.main.mixins import OfficerRequiredMixin
 from wildlifelicensing.apps.main.models import WildlifeLicence
@@ -474,28 +475,8 @@ class DataTableApplicationsOfficerOnBehalfView(OfficerRequiredMixin, base.DataTa
 
     @staticmethod
     def _render_action_column(obj):
-        status = obj.customer_status
-        if status == 'draft':
-            return '<a href="{0}">{1}</a> / <a href="{2}">{3}</a>'.format(
-                reverse('wl_applications:edit_application', args=[obj.pk]),
-                'Continue',
-                reverse('wl_applications:delete_application', args=[obj.pk]),
-                'Discard'
-            )
-        elif status == 'amendment_required' or status == 'id_and_amendment_required':
-            return '<a href="{0}">{1}</a>'.format(
-                reverse('wl_applications:edit_application', args=[obj.pk]),
-                'Amend application'
-            )
-        elif status == 'id_required' and obj.id_check_status == 'awaiting_update':
-            return '<a href="{0}">{1}</a>'.format(
-                reverse('wl_main:identification'),
-                'Update ID')
-        else:
-            return '<a href="{0}">{1}</a>'.format(
-                reverse('wl_applications:view_application', args=[obj.pk]),
-                'View application (read-only)'
-            )
+        # same as a customer
+        return DataTableApplicationCustomerView.render_action_column(obj)
 
     @staticmethod
     def _get_proxy_applications(user):

--- a/wildlifelicensing/templates/wl/confirm_base.html
+++ b/wildlifelicensing/templates/wl/confirm_base.html
@@ -5,7 +5,7 @@
         <form class="form" action="{{ action_url }}" method="post">{% csrf_token %}
             <div class="row">
                 <div class="col-md-8 col-md-offset-2">
-                    <h3 class="text-center">{% block confirm_message %}{{ message }}{% endblock %}</h3>
+                    {% block confirm_message %}<h3 class="text-center">{{ message }}</h3>{% endblock %}
                 </div>
             </div>
             <div class="row top-buffer">


### PR DESCRIPTION
See [specs](https://kanboard.dpaw.wa.gov.au/?controller=TaskViewController&action=show&task_id=2833&project_id=24) for the discard rules.

* Fixed bug when a submitted application sent back to the user could be deleted if the user opened it, saved it as a draft and discarded it.
* Removed the Delete View. Everything is in DiscardView
* Added test to cover the bug.
* This also cover [2830 confirmation message](https://kanboard.dpaw.wa.gov.au/?controller=TaskViewController&action=show&task_id=2830&project_id=24)