### PR TITLE
Fixed problem with image / PDF not displaying in Show ID during application processing.

### DIFF
--- a/wildlifelicensing/apps/applications/templates/wl/process/process_app.html
+++ b/wildlifelicensing/apps/applications/templates/wl/process/process_app.html
@@ -352,7 +352,7 @@
         </div>
     </div>
     {% block modals %}
-        {% with user=data.application.applicant_profile.user %}
+        {% with user=data.application.applicant %}
             {% if user.identification %}
                 <div class="modal fade" id="idModal" tabindex="-1">
                     <div class="modal-dialog" role="document">
@@ -363,16 +363,14 @@
                                     {{ user.last_name }}</h4>
                             </div>
                             <div class="modal-body center">
-                                {% if user.identification.file.url|slice:'-3:' == 'pdf' %}
-                                    <a href="{{ user.identification.file.url }}" target="_blank">
+                                <a href="{{ user.identification.url }}" target="_blank">
+                                    {% if user.identification.url|lower|slice:'-3:' == 'pdf' %}
                                         <img src="{% static 'wl/img/pdf.png' %}">
                                         <p>View PDF</p>
-                                    </a>
-                                {% else %}
-                                    <a href="{{ user.identification.file.url }}" target="_blank">
-                                        <img width="100%" src="{{ user.identification.file.url }}"/>
-                                    </a>
-                                {% endif %}
+                                    {% else %}
+                                        <img width="100%" src="{{ user.identification.url }}"/>
+                                    {% endif %}
+                                </a>
                             </div>
                             <div class="modal-footer">
                                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/wildlifelicensing/apps/applications/utils.py
+++ b/wildlifelicensing/apps/applications/utils.py
@@ -366,7 +366,8 @@ def format_application(instance, attrs):
     attrs['licence_type']['default_conditions'] = serialize([ap.condition for ap in instance.licence_type.defaultcondition_set.order_by('order')])
     attrs['conditions'] = serialize([ap.condition for ap in instance.applicationcondition_set.order_by('order')])
 
-    attrs['applicant']['identification']['url'] = instance.applicant.identification.file.url
+    if instance.applicant.identification is not None and instance.applicant.identification.file is not None: 
+        attrs['applicant']['identification']['url'] = instance.applicant.identification.file.url
 
     return attrs
 

--- a/wildlifelicensing/apps/applications/utils.py
+++ b/wildlifelicensing/apps/applications/utils.py
@@ -366,6 +366,8 @@ def format_application(instance, attrs):
     attrs['licence_type']['default_conditions'] = serialize([ap.condition for ap in instance.licence_type.defaultcondition_set.order_by('order')])
     attrs['conditions'] = serialize([ap.condition for ap in instance.applicationcondition_set.order_by('order')])
 
+    attrs['applicant']['identification']['url'] = instance.applicant.identification.file.url
+
     return attrs
 
 

--- a/wildlifelicensing/apps/main/templates/wl/manage_identification.html
+++ b/wildlifelicensing/apps/main/templates/wl/manage_identification.html
@@ -46,7 +46,7 @@
                 <div class="col-md-4">
                     <h3>Current identification</h3>
                     <div class="center">
-                       {% if existing_id_image_url|slice:'-3:' == 'pdf' %}
+                        {% if existing_id_image_url|slice:'-3:' == 'pdf' %}
                             <a href="{{ existing_id_image_url }}" target="_blank">
                                 <img src="{% static 'wl/img/pdf.png' %}">
                                 <p>View PDF</p>


### PR DESCRIPTION
Because 'user' has been serialized with preserialize, this would not
include the url of the file, which is a dynamic property. Needed to
manually append this to user.identification in preserialize post-hook.