### PR TITLE
2730 Default Filters For Proxy Dashboard 

### DIFF
--- a/wildlifelicensing/apps/dashboard/views/officer.py
+++ b/wildlifelicensing/apps/dashboard/views/officer.py
@@ -364,10 +364,12 @@ class TablesOfficerOnBehalfView(OfficerRequiredMixin, base.TablesBaseView):
     @property
     def applications_filters(self):
         status_filter_values = \
-            [(
+            [('all', 'All'),
+             (
                 TablesApplicationsOfficerView.STATUS_PENDING,
-                TablesApplicationsOfficerView.STATUS_PENDING.capitalize())] + \
-            [('all', 'All')] + \
+                TablesApplicationsOfficerView.STATUS_PENDING.capitalize()
+             ),
+             ] + \
             [s for s in Application.PROCESSING_STATUS_CHOICES]
 
         return {
@@ -427,9 +429,11 @@ class TablesOfficerOnBehalfView(OfficerRequiredMixin, base.TablesBaseView):
 
     @property
     def returns_filters(self):
-        status_filter_values = [(TablesReturnsOfficerView.OVERDUE_FILTER,
-                                 TablesReturnsOfficerView.OVERDUE_FILTER.capitalize())] + \
-                               [('all', 'All')] + list(Return.STATUS_CHOICES)
+        status_filter_values = \
+            [
+                (TablesReturnsOfficerView.STATUS_FILTER_ALL_BUT_DRAFT_OR_FUTURE, 'All (but draft or future)'),
+                (TablesReturnsOfficerView.OVERDUE_FILTER, TablesReturnsOfficerView.OVERDUE_FILTER.capitalize())
+            ] + list(Return.STATUS_CHOICES)
         return {
             'licence_type': self.get_licence_types_values(),
             'status': status_filter_values,


### PR DESCRIPTION
* Changed filters list order for proxy applicant page. Put the 'All' first for application and returns.

[See ticket 2730](https://kanboard.dpaw.wa.gov.au/?controller=TaskViewController&action=show&task_id=2730&project_id=24)