### PR TITLE
Email notifications for overdue returns.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-datatables-view==1.13.0
 django-reversion==1.10.1
 git+https://github.com/scottp-dpaw/django-preserialize.git#egg=django-preserialize
 django-countries==3.4.1
-django-cron==0.4.6
+django-cron==0.5.0
 django-dynamic-fixture==1.9.1
 openpyxl==2.3.5
 datapackage==0.8.1

--- a/wildlifelicensing/apps/returns/cron.py
+++ b/wildlifelicensing/apps/returns/cron.py
@@ -3,17 +3,27 @@ from datetime import date, timedelta
 from django_cron import CronJobBase, Schedule
 
 from wildlifelicensing.apps.returns.models import Return
-from wildlifelicensing.apps.returns.emails import send_return_overdue_email_notification
+from wildlifelicensing.apps.returns.emails import send_return_overdue_email_notification, \
+    send_return_overdue_staff_email_notification
 
 
 class CheckOverdueReturnsCronJob(CronJobBase):
     RUN_AT_TIMES = ['00:00']
+    OVERDUE_DAYS_FIRST_REMINDER = 1
+    OVERDUE_DAYS_SECOND_REMINDER = 7
 
     schedule = Schedule(run_at_times=RUN_AT_TIMES)
     code = 'returns.check_overdue_returns'
 
     def do(self):
-        yesterday = date.today() - timedelta(days=1)
+        # first reminder that is sent to licence holder
+        due_date = date.today() - timedelta(days=self.OVERDUE_DAYS_FIRST_REMINDER)
 
-        for ret in Return.objects.filter(due_date=yesterday).exclude(status='submitted').exclude(status='accepted'):
+        for ret in Return.objects.filter(due_date=due_date).exclude(status__in=['submitted', 'accepted']):
             send_return_overdue_email_notification(ret)
+
+        # second notice that is sent to staff
+        due_date = date.today() - timedelta(days=self.OVERDUE_DAYS_SECOND_REMINDER)
+
+        for ret in Return.objects.filter(due_date=due_date).exclude(status__in=['submitted', 'accepted']):
+            send_return_overdue_staff_email_notification(ret)

--- a/wildlifelicensing/apps/returns/emails.py
+++ b/wildlifelicensing/apps/returns/emails.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.core.urlresolvers import reverse
+from django.conf import settings
 
 from wildlifelicensing.apps.emails.emails import TemplateEmailBase
 
@@ -22,4 +23,28 @@ def send_return_overdue_email_notification(ret):
         'return': ret
     }
 
-    email.send(ret.licence.profile.email, context=context)
+    if ret.proxy_customer is not None:
+        email = ret.proxy_customer.email
+    else:
+        email = ret.licence.profile.email
+
+    email.send(email, context=context)
+
+
+class ReturnOverdueStaffNotificationEmail(TemplateEmailBase):
+    subject = 'Wildlife Licensing [{}]: overdue return'
+    html_template = 'wl/emails/overdue_return_staff_notification.html'
+    txt_template = 'wl/emails/overdue_return_staff_notification.txt'
+
+    def __init__(self, ret):
+        self.subject = self.subject.format(ret.licence.holder.get_full_name())
+
+
+def send_return_overdue_staff_email_notification(ret):
+    email = ReturnOverdueStaffNotificationEmail(ret)
+
+    context = {
+        'return': ret
+    }
+
+    email.send(settings.WILDLIFELICENSING_EMAIL_CATCHALL, context=context)

--- a/wildlifelicensing/apps/returns/templates/wl/emails/overdue_return_staff_notification.html
+++ b/wildlifelicensing/apps/returns/templates/wl/emails/overdue_return_staff_notification.html
@@ -1,0 +1,11 @@
+{%  extends 'wl/emails/base_email.html' %}
+
+{%  block content %}
+    <p>Customer {{ return.licence.holder.get_full_name }} has an overdue return for Wildlife Licence:</p>
+    <p><strong>{{ return.licence.licence_type.name }}</strong></p>
+    <p>that was due on {{ return.due_date }}.
+    {% if return.proxy_customer %}
+        <p>The customer's proxy officer is: {{ return.proxy_customer.get_full_name }}.</p>
+    {% endif %}
+    <p>Note: If you haven't been on the Wildlife Licensing site recently you might have to login first before using the provided link.</p>
+{%  endblock %}

--- a/wildlifelicensing/apps/returns/templates/wl/emails/overdue_return_staff_notification.txt
+++ b/wildlifelicensing/apps/returns/templates/wl/emails/overdue_return_staff_notification.txt
@@ -1,0 +1,15 @@
+{%  extends 'wl/emails/base_email.html' %}
+
+{%  block content %}
+    Customer {{ return.licence.holder.get_full_name }} has an overdue return for Wildlife Licence:
+
+    {{ return.licence.licence_type.name }}
+
+    that was due on {{ return.due_date }}.
+    {% if return.proxy_customer %}
+
+        The customer's proxy officer is: {{ return.proxy_customer.get_full_name }}.
+
+    {% endif %}
+    Note: If you haven't been on the Wildlife Licensing site recently you might have to login first before using the provided link.
+{%  endblock %}


### PR DESCRIPTION
Needed to update django-cron version to 0.5.0 to work with Django 1.10.

Two types of reminders:

First to licence holder if return one day overdue. This will now go to
proxy officer if there is one.

Second to WL staff if return is one week overdue.