### PR TITLE
3407 concurrent applications

### DIFF
--- a/wildlifelicensing/apps/applications/mixins.py
+++ b/wildlifelicensing/apps/applications/mixins.py
@@ -133,7 +133,7 @@ class RedirectApplicationInSessionMixin(object):
         if 'application_id' in request.session:
             messages.error(request, 'There is currently another application in the process of being entered. Please '
                            'conclude or save this application before creating a new one. If you are seeing this '
-                           'message and are not another application being entered, you may need to <a href="{}">logout'
+                           'message and there is not another application being entered, you may need to <a href="{}">logout'
                            '</a> and log in again.'.format(reverse('accounts:logout')))
             return redirect('home')
 

--- a/wildlifelicensing/apps/applications/mixins.py
+++ b/wildlifelicensing/apps/applications/mixins.py
@@ -1,6 +1,6 @@
 import datetime
 
-from django.core.urlresolvers import reverse_lazy
+from django.core.urlresolvers import reverse, reverse_lazy
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib import messages
 from django.shortcuts import redirect
@@ -131,8 +131,10 @@ class RedirectApplicationInSessionMixin(object):
     """
     def dispatch(self, request, *args, **kwargs):
         if 'application_id' in request.session:
-            messages.error(request, 'There is currently an application in the process of being entered. Please '
-                           'conclude or save this application before creating a new one.')
+            messages.error(request, 'There is currently another application in the process of being entered. Please '
+                           'conclude or save this application before creating a new one. If you are seeing this '
+                           'message and are not another application being entered, you may need to <a href="{}">logout'
+                           '</a> and log in again.'.format(reverse('accounts:logout')))
             return redirect('home')
 
         return super(RedirectApplicationInSessionMixin, self).dispatch(request, *args, **kwargs)

--- a/wildlifelicensing/apps/applications/mixins.py
+++ b/wildlifelicensing/apps/applications/mixins.py
@@ -123,18 +123,33 @@ class UserCanAmendApplicationMixin(UserPassesTestMixin):
             return False
 
 
-class ApplicationNotInSessionMixin(object):
+class RedirectApplicationInSessionMixin(object):
     """
-    Mixin to check that there is not currently an application in the session, in the case an application is 
+    Mixin to check if there is currently an application in the session and if so, redirect to home with a message. This
+    is for the case when a view is about to start entering application details but another application is currently
     being entered.
     """
     def dispatch(self, request, *args, **kwargs):
         if 'application_id' in request.session:
-            messages.error(request, 'There is currently an application already being entered. Please conclude or save '
-                                    'this application before creating a new one.')
+            messages.error(request, 'There is currently an application in the process of being entered. Please '
+                           'conclude or save this application before creating a new one.')
             return redirect('home')
 
-        return super(ApplicationNotInSessionMixin, self).dispatch(request, *args, **kwargs)
+        return super(RedirectApplicationInSessionMixin, self).dispatch(request, *args, **kwargs)
+
+
+class RedirectApplicationNotInSessionMixin(object):
+    """
+    Mixin to check if an application is in the session, and if not, redirect to home with a message. This is the case
+    where an application is being edited but somehow the session has become corrupt and there is no longer an
+    application referenced there.
+    """
+    def dispatch(self, request, *args, **kwargs):
+        if 'application_id' not in request.session:
+            messages.error(request, 'The application session was corrupted.')
+            return redirect('home')
+
+        return super(RedirectApplicationNotInSessionMixin, self).dispatch(request, *args, **kwargs)
 
 
 class CanPerformAssessmentMixin(UserPassesTestMixin):

--- a/wildlifelicensing/apps/applications/static/wl/js/entry/navigation.js
+++ b/wildlifelicensing/apps/applications/static/wl/js/entry/navigation.js
@@ -36,11 +36,6 @@ define(['jQuery'], function($) {
                             csrfmiddlewaretoken: csrfToken
                         }
                     });
-//                    $.post('/delete-application-session/', {
-//                            applicationId: applicationId,
-//                            csrfmiddlewaretoken: csrfToken
-//                        }
-//                    );
                 }
             };
         }

--- a/wildlifelicensing/apps/applications/static/wl/js/entry/navigation.js
+++ b/wildlifelicensing/apps/applications/static/wl/js/entry/navigation.js
@@ -1,31 +1,48 @@
 define(['jQuery'], function($) {
-    return {setupNavigateAway: function(message) {
-        var $lastClicked;
+    return {
+        init: function(message, applicationId, contentContainerSelector, csrfToken) {
+            var $contentContainer = $(contentContainerSelector),
+                isExpectedNavigationAction = false;
 
-        $('a, :button').click(function(e) {
-            $lastClicked = $(this); 
-        });
+            $('a, :button').click(function(e) {
+                isExpectedNavigationAction = $contentContainer.find(this).length > 0;
+            });
 
-        window.onbeforeunload = function (e) {
-            // if we haven't been passed the event get the window.event
-            e = e || window.event;
+            window.onbeforeunload = function (e) {
+                // if we haven't been passed the event get the window.event
+                e = e || window.event;
 
-            // if link is for current page or has data-entry-link
-            if(!$lastClicked.attr('href') ||
-               ($lastClicked.attr('href').indexOf(window.location.href) > -1 ||
-                $lastClicked.attr('data-entry-link'))) {
-                return;
+                if(!isExpectedNavigationAction) {
+                    // Note: You cannot change the custom message for onbeforeunload in Chrome / Firefox
+
+                    // for IE6-8 and Firefox prior to version 4
+                    if (e) {
+                        e.returnValue = message;
+                    }
+
+                    // for Safari, IE8+ and Opera 12+
+                    return message;
+                }
             };
 
-            // Note: You cannot change the custom message for onbeforeunload in Chrome / Firefox
-            
-            // for IE6-8 and Firefox prior to version 4
-            if (e) {
-                e.returnValue = message;
-            }
-
-            // for Safari, IE8+ and Opera 12+
-            return message;
-        };
-    }}
+            window.onunload = function (e) {
+                if(!isExpectedNavigationAction) {
+                    $.ajax({
+                        type: 'POST',
+                        url: '/applications/delete-application-session/',
+                        async: false,
+                        data: { 
+                            applicationId: applicationId,
+                            csrfmiddlewaretoken: csrfToken
+                        }
+                    });
+//                    $.post('/delete-application-session/', {
+//                            applicationId: applicationId,
+//                            csrfmiddlewaretoken: csrfToken
+//                        }
+//                    );
+                }
+            };
+        }
+    }
 });

--- a/wildlifelicensing/apps/applications/static/wl/js/entry/select_licence_type.js
+++ b/wildlifelicensing/apps/applications/static/wl/js/entry/select_licence_type.js
@@ -5,7 +5,7 @@ define(['jQuery', 'js/wl.bootstrap-treeview'], function ($) {
         return text.toLowerCase().replace(/ /g,'-').replace(/[^\w-]+/g,'');
     }
 
-    function _init(categories) {
+    function _initCategories(categories) {
         $.each(categories, function(index, value) {
             var $tree = $('#' + _convertToSlug(value.name));
 
@@ -30,6 +30,38 @@ define(['jQuery', 'js/wl.bootstrap-treeview'], function ($) {
                 }
             });
         });
+    }
+
+    function _initNavigateAway(deleteApplicationSessionURL, applicationId, csrfToken, categoryContainerSelector) {
+        var $categoryContainer = $(categoryContainerSelector),
+            $lastClicked;
+
+        $('a, :button').click(function(e) {
+            $lastClicked = $(this);
+        });
+
+        window.onbeforeunload = function (e) {
+            // if we haven't been passed the event get the window.event
+            e = e || window.event;
+
+            // if link is for current page or child of main
+            if(!$lastClicked.attr('href') ||
+               ($lastClicked.attr('href').indexOf(window.location.href) > -1 ||
+                $categoryContainer.find($lastClicked).length > 0)) {
+                return;
+            };
+
+            $.post(deleteApplicationSessionURL, {
+                    applicationId: applicationId,
+                    csrfmiddlewaretoken: csrfToken
+                }
+            );
+        };
+    }
+
+    function _init(options) {
+        _initCategories(options.categories);
+        _initNavigateAway(options.deleteApplicationSessionURL, options.applicationId, options.csrfToken);
     }
 
     return {

--- a/wildlifelicensing/apps/applications/static/wl/js/entry/select_licence_type.js
+++ b/wildlifelicensing/apps/applications/static/wl/js/entry/select_licence_type.js
@@ -34,34 +34,27 @@ define(['jQuery', 'js/wl.bootstrap-treeview'], function ($) {
 
     function _initNavigateAway(deleteApplicationSessionURL, applicationId, csrfToken, categoryContainerSelector) {
         var $categoryContainer = $(categoryContainerSelector),
-            $lastClicked;
+            isLinkLicenceSelection = false;
 
-        $('a, :button').click(function(e) {
-            $lastClicked = $(this);
+        $('a').click(function(e) {
+            isLinkLicenceSelection = $categoryContainer.find(this).length > 0;
         });
 
-        window.onbeforeunload = function (e) {
-            // if we haven't been passed the event get the window.event
-            e = e || window.event;
-
-            // if link is for current page or child of main
-            if(!$lastClicked.attr('href') ||
-               ($lastClicked.attr('href').indexOf(window.location.href) > -1 ||
-                $categoryContainer.find($lastClicked).length > 0)) {
-                return;
-            };
-
-            $.post(deleteApplicationSessionURL, {
-                    applicationId: applicationId,
-                    csrfmiddlewaretoken: csrfToken
-                }
-            );
+        window.onunload = function (e) {
+            if(!isLinkLicenceSelection) {
+                $.post(deleteApplicationSessionURL, {
+                        applicationId: applicationId,
+                        csrfmiddlewaretoken: csrfToken
+                    }
+                );
+            }
         };
     }
 
     function _init(options) {
         _initCategories(options.categories);
-        _initNavigateAway(options.deleteApplicationSessionURL, options.applicationId, options.csrfToken);
+        _initNavigateAway(options.deleteApplicationSessionURL, options.applicationId, options.csrfToken,
+                options.categoryContainerSelector);
     }
 
     return {

--- a/wildlifelicensing/apps/applications/static/wl/js/entry/select_licence_type.js
+++ b/wildlifelicensing/apps/applications/static/wl/js/entry/select_licence_type.js
@@ -32,29 +32,8 @@ define(['jQuery', 'js/wl.bootstrap-treeview'], function ($) {
         });
     }
 
-    function _initNavigateAway(deleteApplicationSessionURL, applicationId, csrfToken, categoryContainerSelector) {
-        var $categoryContainer = $(categoryContainerSelector),
-            isLinkLicenceSelection = false;
-
-        $('a').click(function(e) {
-            isLinkLicenceSelection = $categoryContainer.find(this).length > 0;
-        });
-
-        window.onunload = function (e) {
-            if(!isLinkLicenceSelection) {
-                $.post(deleteApplicationSessionURL, {
-                        applicationId: applicationId,
-                        csrfmiddlewaretoken: csrfToken
-                    }
-                );
-            }
-        };
-    }
-
     function _init(options) {
         _initCategories(options.categories);
-        _initNavigateAway(options.deleteApplicationSessionURL, options.applicationId, options.csrfToken,
-                options.categoryContainerSelector);
     }
 
     return {

--- a/wildlifelicensing/apps/applications/templates/wl/entry/complete.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/complete.html
@@ -8,12 +8,14 @@
 
 {% load users %}
 
+{% load application_filters %}
+
 {% block breadcrumbs %}
     <div class="container">
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
-                    <li><a href="{% url 'home' %}">Home</a></li>
+                    <li><strong>{{ application|get_application_verb }} Application</strong></li>
                     <li class="active">Application Complete</li>
                 </ol>
             </div>
@@ -41,7 +43,7 @@
             Thank you. Your application will now be reviewed.
         </p>
         <p>
-            You can see the status of the application on your home screen dashboard in the “Applications” table and view a
+            You can see the status of the application on your home screen dashboard in the "Applications" table and view a
             read-only version of the application. 
         </p>
         <p>

--- a/wildlifelicensing/apps/applications/templates/wl/entry/create_select_customer.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/create_select_customer.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block requirements %}
-    require(['js/entry/create_select_customer', 'js/entry/navigation'], function (create_select_customer) {
+    require(['js/entry/create_select_customer', 'js/entry/navigation'], function (create_select_customer, navigation) {
         create_select_customer.init();
 
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',

--- a/wildlifelicensing/apps/applications/templates/wl/entry/create_select_customer.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/create_select_customer.html
@@ -4,6 +4,8 @@
 
 {% load bootstrap3 %}
 
+{% load application_filters %}
+
 {% block extra_css %}
     <link href="//static.dpaw.wa.gov.au/static/libs/select2/3.5.3/select2.min.css" rel="stylesheet"/>
     <link href="//static.dpaw.wa.gov.au/static/libs/select2-bootstrap-css/1.4.6/select2-bootstrap.css" rel="stylesheet"/>
@@ -13,19 +15,20 @@
 {% endblock %}
 
 {% block requirements %}
-    require(['js/entry/create_select_customer'], function (create_select_customer) {
-        $(function () {
-            create_select_customer.init();
-        });
+    require(['js/entry/create_select_customer', 'js/entry/navigation'], function (create_select_customer) {
+        create_select_customer.init();
+
+        navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
+            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 
 {% block breadcrumbs %}
-    <div class="container">
+    <div id="breadcrumbsContainer" class="container">
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
-                    <li><a href="{% url 'home' %}">Home</a></li>
+                    <li><strong>{{ application|get_application_verb }} Application</strong></li>
                     <li class="active">Select or Create Customer</li>
                 </ol>
             </div>
@@ -37,7 +40,7 @@
 {% block intro_subtitle %}<h4>Select or create the customer for whom the application is being applied on behalf of.</h4>{% endblock %}
 
 {% block content %}
-    <div class="container bottom-buffer">
+    <div id="contentContainer" class="container bottom-buffer">
         <div class="row">
             <div class="col-md-12">
                 <form method="post">

--- a/wildlifelicensing/apps/applications/templates/wl/entry/create_select_profile.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/create_select_profile.html
@@ -6,6 +6,8 @@
 
 {% load users %}
 
+{% load application_filters %}
+
 {% block requirements %}
     require(['js/entry/navigation'], function(navigation) {
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
@@ -18,13 +20,7 @@
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
-                    <li><a href="{% url 'home' %}">Home</a></li>
-                    {% if application.is_temporary %}
-                        {% if request.user|is_officer %}
-                            <li><a href="{% url 'wl_applications:create_select_customer' %}">Select or Create Customer</a></li>
-                        {% endif %}
-                        <li><a href="{% url 'wl_applications:select_licence_type' %}">Select Licence Type</a></li>
-                    {% endif %}
+                    <li><strong>{{ application|get_application_verb }} Application</strong></li>
                     <li class="active">{% if profile_selection_form %}Select{% else %}Create{% endif %} Profile</li>
                 </ol>
             </div>
@@ -35,7 +31,7 @@
 {% block intro_title %}<h3>Select Profile</h3>{% endblock %}
 {% block intro_subtitle %}
     <h4 class="inline">
-        {{ licence_type.name }} {% if is_renewal %}(Renewal) {% endif %} {% if is_amendment %}(Amendment) {% endif %}
+        {{ application.licence_type.name }} {% if is_renewal %}(Renewal) {% endif %} {% if is_amendment %}(Amendment) {% endif %}
     </h4> 
     {% if customer %}
             <h4 class="pull-right">Customer: {{ customer.get_full_name }}</h4>
@@ -48,18 +44,18 @@
 {% endblock %}
 {% block intro_text %}
     <p>
-        The Wildlife Licensing System utilises the concept of “profiles” to allow users to hold licences under different circumstances,
+        The Wildlife Licensing System utilises the concept of "profiles" to allow users to hold licences under different circumstances,
         rather than registering numerous accounts. Each profile can have a different email address, postal address and affiliation details.
     </p>
     <p>
-        For example, a registered user may have a “Consultant” profile for work/employment purposes, a “Friends of”
-        profile for volunteer work, and a “Personal” profile for private licences.
+        For example, a registered user may have a "Consultant" profile for work/employment purposes, a "Friends of"
+        profile for volunteer work, and a "Personal" profile for private licences.
     </p>
     <p>
         Please select an existing profile or alternatively create a new profile for this licence application.
     </p>
     <p>
-        To manage your profiles generally you can click on “Options” on top-right toolbar and choose “Manage Profile.”
+        To manage your profiles generally you can click on "Options" on top-right toolbar and choose "Manage Profile."
     </p>
 
 {% endblock %}

--- a/wildlifelicensing/apps/applications/templates/wl/entry/create_select_profile.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/create_select_profile.html
@@ -8,12 +8,13 @@
 
 {% block requirements %}
     require(['js/entry/navigation'], function(navigation) {
-        navigation.setupNavigateAway('Warning: any information entered into the form will be lost if not saved as draft.');
+        navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
+            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 
 {% block breadcrumbs %}
-    <div class="container">
+    <div id="breadcrumbsContainer" class="container">
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
@@ -64,7 +65,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="container bottom-buffer">
+    <div id="contentContainer" class="container bottom-buffer">
         {% if profile_selection_form %}
             <div class="row">
                 <div class="col-md-12">

--- a/wildlifelicensing/apps/applications/templates/wl/entry/enter_details.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/enter_details.html
@@ -10,6 +10,8 @@
 
 {% load url_helpers %}
 
+{% load application_filters %}
+
 {% block extra_css %}
     <link href="//static.dpaw.wa.gov.au/static/libs/select2/3.5.4/select2.min.css" rel="stylesheet"/>
     <link href="//static.dpaw.wa.gov.au/static/libs/select2-bootstrap-css/1.4.6/select2-bootstrap.css" rel="stylesheet"/>
@@ -43,13 +45,7 @@
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
-                    <li><a href="{% url 'home' %}">Home</a></li>
-                    {% if application.is_temporary %}
-                        {% if request.user|is_officer %}
-                            <li><a href="{% url 'wl_applications:create_select_customer' %}">Select or Create Customer</a></li>
-                        {% endif %}
-                        <li><a href="{% url 'wl_applications:select_licence_type' %}">Select Licence Type</a></li>
-                    {% endif %}
+                    <li><strong>{{ application|get_application_verb }} Application</strong></li>
                     <li><a href="{% url 'wl_applications:create_select_profile' %}">Select Profile</a></li>
                     <li class="active">Enter Application Details</li>
                 </ol>
@@ -78,15 +74,15 @@
         Answers that simply refer to an attached research proposal will not be accepted.
     </p>
     <p>
-        When you are satisfied with your answers, click the “Preview Application” button at the bottom-right.
+        When you are satisfied with your answers, click the "Preview Application" button at the bottom-right.
     </p>
     <p>
-        At any point you can save your application as a draft by clicking the “Save Draft” button at the bottom,
-        allowing you to return to the application at a later time (you will find it listed in the “Applications”
+        At any point you can save your application as a draft by clicking the "Save Draft" button at the bottom,
+        allowing you to return to the application at a later time (you will find it listed in the "Applications"
         table on your home screen dashboard).
     </p>
     <p>
-        It is suggested that you click the “Save Draft and Continue Editing” button at the bottom at regular
+        It is suggested that you click the "Save Draft and Continue Editing" button at the bottom at regular
         intervals to ensure you do not lose information while completing the form.
     </p>
 {% endblock %}

--- a/wildlifelicensing/apps/applications/templates/wl/entry/enter_details.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/enter_details.html
@@ -21,7 +21,7 @@
         applicationDetails.layoutFormItems('#formContainer', {{ application.licence_type.application_schema|jsonify }}
             {% if application.data %}, {{ application.data|jsonify }}{% endif %});
 
-        $('#mainContainer').removeClass('hidden');
+        $('#contentContainer').removeClass('hidden');
 
         // need to initialise sidebar menu after showing main container otherwise affix height will be wrong
         applicationDetails.initialiseSidebarMenu('#sectionList');
@@ -33,12 +33,13 @@
             }
         });
 
-        navigation.setupNavigateAway('Warning: any information entered into the form will be lost if not saved as draft.');
+        navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
+            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 
 {% block breadcrumbs %}
-    <div class="container">
+    <div id="breadcrumbsContainer" class="container">
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
@@ -91,7 +92,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="mainContainer" class="container hidden">
+    <div id="contentContainer" class="container hidden bottom-buffer">
         {% if amendments %}
             <div class="row">
                 <div class="col-sm-2 col-md-10 col-md-offset-2">

--- a/wildlifelicensing/apps/applications/templates/wl/entry/preview.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/preview.html
@@ -8,6 +8,8 @@
 
 {% load users %}
 
+{% load application_filters %}
+
 {% block requirements %}
     require(['jQuery',
              'js/entry/application_preview',
@@ -32,15 +34,9 @@
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
-                    <li><a href="{% url 'home' %}">Home</a></li>
-                    {% if application.is_temporary %}
-                        {% if request.user|is_officer %}
-                            <li><a href="{% url 'wl_applications:create_select_customer' %}">Select or Create Customer</a></li>
-                        {% endif %}
-                        <li><a href="{% url 'wl_applications:select_licence_type' %}">Select Licence Type</a></li>
-                    {% endif %}
-                    <li><a data-entry-link="True" href="{% url 'wl_applications:create_select_profile' %}">Select Profile</a></li>
-                    <li><a data-entry-link="True" href="{% url 'wl_applications:enter_details' %}">Enter Application Details</a></li>
+                    <li><strong>{{ application|get_application_verb }} Application</strong></li>
+                    <li><a href="{% url 'wl_applications:create_select_profile' %}">Select Profile</a></li>
+                    <li><a href="{% url 'wl_applications:enter_details' %}">Enter Application Details</a></li>
                     <li class="active">Preview and Lodge Application</li>
                 </ol>
             </div>
@@ -66,15 +62,15 @@
     <p>
         This is your application information as it will be seen by an assessing officer. Please review the information
         for detail and accuracy before lodging your application. If you need to change any answers, return to the
-        application by clicking the “Edit Application Details” button at the bottom-left.
+        application by clicking the "Edit Application Details" button at the bottom-left.
     </p>
     <p>
         {% if is_payment_required %}
             When you are satisfied with your answers, read, agree with and check the disclaimer checkboxes
-            and click the “Proceed to Payment” button at the bottom-right.
+            and click the "Proceed to Payment" button at the bottom-right.
         {% else %}
             When you are satisfied with your answers, read, agree with and check the disclaimer checkboxes
-            and click the “Lodge Application” button at the bottom-right.
+            and click the "Lodge Application" button at the bottom-right.
         {% endif %}
     </p>
     <p>

--- a/wildlifelicensing/apps/applications/templates/wl/entry/preview.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/preview.html
@@ -15,19 +15,20 @@
         applicationPreview.layoutPreviewItems('#formContainer', {{ application.licence_type.application_schema|jsonify }},
                                               {{ application.data|jsonify }});
 
-        $('#mainContainer').removeClass('hidden');
+        $('#contentContainer').removeClass('hidden');
 
         // need to initialise sidebar menu after showing main container otherwise affix height will be wrong
         applicationPreview.initialiseSidebarMenu('#sectionList');
 
         applicationPreview.setupDisclaimer($('#disclaimers').find('input[type=checkbox]'), '#lodge');
 
-        navigation.setupNavigateAway('Warning: any information entered into the form will be lost if not saved as draft.');
+        navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
+            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 
 {% block breadcrumbs %}
-    <div class="container">
+    <div id="breadcrumbsContainer" class="container">
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
@@ -84,7 +85,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="mainContainer" class="container hidden">
+    <div id="contentContainer" class="container hidden bottom-buffer">
         <div class="row">
             <div class="col-md-2 col-sm-3">
                 <label class="top-buffer">Selected Profile:</label>

--- a/wildlifelicensing/apps/applications/templates/wl/entry/select_licence_type.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/select_licence_type.html
@@ -10,7 +10,13 @@
 
 {% block requirements %}
     require(['js/entry/select_licence_type'], function(selectLicenceType) {
-        selectLicenceType.init({{ categories|jsonify }});
+        selectLicenceType.init({
+            categories: {{ categories|jsonify }},
+            deleteApplicationSessionURL: '{% url 'wl_applications:delete_application_session' %}',
+            applicationId: {{ application.id }},
+            csrfToken: '{{ csrf_token }}',
+            categoryContainerSelector: '#categoriesContainer'
+        });
     });
 {% endblock %}
 
@@ -44,7 +50,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="container">
+    <div id="categoriesContainer" class="container">
         {% for category in categories %}
             <h4>{{ category.name }}</h4>
             <div class="row">

--- a/wildlifelicensing/apps/applications/templates/wl/entry/select_licence_type.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/select_licence_type.html
@@ -9,11 +9,11 @@
 {% load users %}
 
 {% block requirements %}
-    require(['js/entry/select_licence_type'], function(selectLicenceType) {
+    require(['js/entry/select_licence_type', 'js/entry/navigation'], function(selectLicenceType, navigation) {
         selectLicenceType.init({
             categories: {{ categories|jsonify }},
         });
-        
+
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
             {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
@@ -46,7 +46,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="categoriesContainer" class="container">
+    <div id="contentContainer" class="container">
         {% for category in categories %}
             <h4>{{ category.name }}</h4>
             <div class="row">

--- a/wildlifelicensing/apps/applications/templates/wl/entry/select_licence_type.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/select_licence_type.html
@@ -12,24 +12,20 @@
     require(['js/entry/select_licence_type'], function(selectLicenceType) {
         selectLicenceType.init({
             categories: {{ categories|jsonify }},
-            deleteApplicationSessionURL: '{% url 'wl_applications:delete_application_session' %}',
-            applicationId: {{ application.id }},
-            csrfToken: '{{ csrf_token }}',
-            categoryContainerSelector: '#categoriesContainer'
         });
+        
+        navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
+            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 
 {% block breadcrumbs %}
-    <div class="container">
+    <div id="breadcrumbsContainer" class="container">
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
-                    <li><a href="{% url 'home' %}">Home</a></li>
-                    {% if application.is_temporary and request.user|is_officer %}
-                        <li><a href="{% url 'wl_applications:create_select_customer' %}">Select or Create Customer</a></li>
-                    {% endif %}
-                    <li class="active">New Licence Application - Select Licence Type</li>
+                    <li><strong>New Application</strong></li>
+                    <li class="active">Select Licence Type</li>
                 </ol>
             </div>
         </div>

--- a/wildlifelicensing/apps/applications/templates/wl/entry/upload_identification.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/upload_identification.html
@@ -6,18 +6,21 @@
 
 {% load users %}
 
+{% load application_filters %}
+
+{% block requirements %}
+    require(['js/entry/navigation'], function(navigation) {
+        navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
+            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
+    });
+{% endblock %}
+
 {% block breadcrumbs %}
-    <div class="container">
+    <div id="breadcrumbsContainer" class="container">
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
-                    <li><a href="{% url 'home' %}">Home</a></li>
-                    {% if application.is_temporary %}
-                        {% if request.user|is_officer %}
-                            <li><a href="{% url 'wl_applications:create_select_customer' %}">Select or Create Customer</a></li>
-                        {% endif %}
-                        <li><a href="{% url 'wl_applications:select_licence_type' %}">Select Licence Type</a></li>
-                    {% endif %}
+                    <li><strong>{{ application|get_application_verb }} Application</strong></li>
                     <li class="active">Upload Identification</li>
                 </ol>
             </div>
@@ -53,7 +56,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="container">
+    <div id="contentContainer" class="container">
         <div class="row">
             <div class="col-md-12">
                 <form method="post" enctype="multipart/form-data">

--- a/wildlifelicensing/apps/applications/templates/wl/entry/upload_identification.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/upload_identification.html
@@ -31,7 +31,7 @@
         {{ licence_type.name }} {% if is_renewal %}(Renewal) {% endif %} {% if is_amendment %}(Amendment) {% endif %}
     </h4> 
     {% if customer %}
-            <h4 class="pull-right">Customer: {{ customer.get_full_name }}</h4>
+        <h4 class="pull-right">Customer: {{ customer.get_full_name }}</h4>
     {% endif %}
     {% if variants %}
         <h4>

--- a/wildlifelicensing/apps/applications/templates/wl/entry/upload_senior_card.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/upload_senior_card.html
@@ -4,17 +4,21 @@
 
 {% load users %}
 
+{% load application_filters %}
+
+{% block requirements %}
+    require(['js/entry/navigation'], function(navigation) {
+        navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
+            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
+    });
+{% endblock %}
+
 {% block breadcrumbs %}
-    <div class="container">
+    <div id="breadcrumbsContainer" class="container">
         <div class="row">
             <div class="col-md-12">
                 <ol class="breadcrumb wl-breadcrumbs">
-                    <li><a href="{% url 'home' %}">Home</a></li>
-                    {% if request.user|is_officer %}
-                        <li><a href="{% url 'wl_applications:create_select_customer' %}">Select or Create Customer</a>
-                        </li>
-                    {% endif %}
-                    <li><a href="{% url 'wl_applications:select_licence_type' %}">Select Licence Type</a></li>
+                    <li><strong>{{ application|get_application_verb }} Application</strong></li>
                     <li class="active">Upload Senior Card</li>
                 </ol>
             </div>
@@ -68,7 +72,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="container">
+    <div id="contentContainer" class="container">
         <div class="row">
             <div class="col-md-12">
                 <form method="post" enctype="multipart/form-data">

--- a/wildlifelicensing/apps/applications/templatetags/application_filters.py
+++ b/wildlifelicensing/apps/applications/templatetags/application_filters.py
@@ -1,5 +1,8 @@
 from django.template.defaulttags import register
 
+from wildlifelicensing.apps.applications.models import Application
+
+
 MAX_COLS = 12
 
 
@@ -11,3 +14,16 @@ def derive_col_width(num_cols):
         return 1
     else:
         return int(MAX_COLS / num_cols)
+
+
+@register.filter
+def get_application_verb(application):
+    if application.previous_application is not None:
+        if application.is_licence_amendment:
+            return 'Amend'
+        else:
+            return 'Renew'
+    elif application.is_temporary:
+        return 'New'
+    else:
+        return 'Edit'

--- a/wildlifelicensing/apps/applications/urls.py
+++ b/wildlifelicensing/apps/applications/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
-from wildlifelicensing.apps.applications.views.entry import NewApplicationView, SelectLicenceTypeView, \
-    CreateSelectCustomer, EditApplicationView, CheckIdentificationRequiredView, \
+from wildlifelicensing.apps.applications.views.entry import DeleteApplicationSessionView, NewApplicationView, \
+    SelectLicenceTypeView, CreateSelectCustomer, EditApplicationView, CheckIdentificationRequiredView, \
     CreateSelectProfileView, EnterDetailsView, PreviewView, ApplicationCompleteView, RenewLicenceView, \
     AmendLicenceView, CheckSeniorCardView, DiscardApplicationView
 
@@ -20,6 +20,7 @@ from wildlifelicensing.apps.applications.views.view import ViewReadonlyView, Vie
 
 urlpatterns = [
     # application entry / licence renewal/amendment
+    url('^delete-application-session/$', DeleteApplicationSessionView.as_view(), name='delete_application_session'),
     url('^new-application/$', NewApplicationView.as_view(), name='new_application'),
     url('^select-licence-type$', SelectLicenceTypeView.as_view(), name='select_licence_type'),
     url('^select-licence-type/([0-9]+)$', SelectLicenceTypeView.as_view(), name='select_licence_type'),

--- a/wildlifelicensing/apps/applications/views/entry.py
+++ b/wildlifelicensing/apps/applications/views/entry.py
@@ -7,6 +7,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http.response import HttpResponse, HttpResponseForbidden
 from django.utils.http import urlencode
+from django.core.urlresolvers import reverse
 
 from ledger.accounts.models import EmailUser, Document
 from ledger.accounts.forms import EmailUserForm, AddressForm, ProfileForm
@@ -18,11 +19,10 @@ from wildlifelicensing.apps.applications.models import Application, AmendmentReq
     ApplicationVariantLink, ApplicationUserAction
 from wildlifelicensing.apps.applications import utils
 from wildlifelicensing.apps.applications.forms import ProfileSelectionForm
-from wildlifelicensing.apps.applications.mixins import UserCanEditApplicationMixin, \
-    UserCanViewApplicationMixin, UserCanRenewApplicationMixin, UserCanAmendApplicationMixin
+from wildlifelicensing.apps.applications.mixins import UserCanEditApplicationMixin, UserCanViewApplicationMixin, \
+    UserCanRenewApplicationMixin, UserCanAmendApplicationMixin, ApplicationNotInSessionMixin
 from wildlifelicensing.apps.main.mixins import OfficerRequiredMixin, OfficerOrCustomerRequiredMixin
 from wildlifelicensing.apps.main.helpers import is_customer, render_user_name
-from django.core.urlresolvers import reverse
 from wildlifelicensing.apps.applications.utils import delete_session_application
 from wildlifelicensing.apps.payments.utils import is_licence_free, get_licence_price, \
     generate_product_title
@@ -72,7 +72,7 @@ class DeleteApplicationSessionView(OfficerOrCustomerRequiredMixin, View):
         return HttpResponse()
 
 
-class NewApplicationView(OfficerOrCustomerRequiredMixin, View):
+class NewApplicationView(OfficerOrCustomerRequiredMixin, ApplicationNotInSessionMixin, View):
     def get(self, request, *args, **kwargs):
         utils.remove_temp_applications_for_user(request.user)
 

--- a/wildlifelicensing/apps/dashboard/views/base.py
+++ b/wildlifelicensing/apps/dashboard/views/base.py
@@ -19,7 +19,6 @@ from django.utils.http import urlencode
 
 from ledger.licence.models import LicenceType
 from wildlifelicensing.apps.applications.models import Application
-from wildlifelicensing.apps.applications.utils import remove_temp_applications_for_user
 from wildlifelicensing.apps.dashboard.forms import LoginForm
 from wildlifelicensing.apps.main.helpers import is_officer, is_assessor, render_user_name
 
@@ -444,8 +443,6 @@ class TablesBaseView(TemplateView):
         return self.request.GET.dict()
 
     def get_context_data(self, **kwargs):
-        remove_temp_applications_for_user(self.request.user)
-
         if 'dataJSON' not in kwargs:
             data = {
                 'applications': self.get_applications_context_data() or None,


### PR DESCRIPTION
Main aim of this branch is to make it so that a user cannot edit more than one application at the same time, to avoid data in session overwriting data of other application.

Two new mixins:
- **RedirectApplicationInSessionMixin**: Prevent's a view that starts the application process - new/edit/amend/reissue - from doing so if there is already an application in the session. Will redirect home with a message if there is another application in progress.

- **RedirectApplicationNotInSessionMixin**: For all other data entry views to ensure that there is an application in the session. Redirect home with a message if there is no application in the session.

Another view called **DeleteApplicationSessionView**: This will be called by javascript modules if a page closes unexpectedly, such as a user selecting a non-application link (i.e. the nav-bar), clicking back/forward/reload or closing the window/tab. This makes sure that the application in session is deleted so that another can be started.

The navigation.js module is now used for all pages that are part of the application process, and behaves the same way for each. That is:
- a window before unload function that prompts the user if they are sure they want to leave when leaving the page unexpectedly.
- a window unload function that calls the above mentioned DelteApplicationSessionView view if when the user does leave the page unexpectly.

All breadcrumbs have been refactored. Home and Select Licence Type no longer appear, as they will cause the application to be deleted or altered in an undesirable way. Only want breadcrumbs that will maintain the application's correct state available.

There is also a new non-clickable breadcrumb that will say "New / Edit / Amend / Reissue Application" depending on the application state.