### PR TITLE
Fixes for issues 3191, 3222, 3411

### DIFF
--- a/wildlifelicensing/apps/applications/models.py
+++ b/wildlifelicensing/apps/applications/models.py
@@ -118,7 +118,7 @@ class Application(RevisionedMixin):
 
     @property
     def is_temporary(self):
-        return self.customer_status == 'temp' and self.processing_status == 'temp'
+        return self.customer_status == 'temp'
 
     @property
     def can_user_edit(self):

--- a/wildlifelicensing/apps/applications/static/wl/js/entry/navigation.js
+++ b/wildlifelicensing/apps/applications/static/wl/js/entry/navigation.js
@@ -1,10 +1,10 @@
 define(['jQuery'], function($) {
     return {
-        init: function(message, applicationId, contentContainerSelector, csrfToken) {
+        init: function(message, applicationId, navigationElementSelector, contentContainerSelector, csrfToken) {
             var $contentContainer = $(contentContainerSelector),
                 isExpectedNavigationAction = false;
 
-            $('a, :button').click(function(e) {
+            $(navigationElementSelector).click(function(e) {
                 isExpectedNavigationAction = $contentContainer.find(this).length > 0;
             });
 

--- a/wildlifelicensing/apps/applications/templates/wl/entry/create_select_customer.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/create_select_customer.html
@@ -19,7 +19,7 @@
         create_select_customer.init();
 
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
-            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
+            {{ application.id }}, 'a, :button', '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 

--- a/wildlifelicensing/apps/applications/templates/wl/entry/create_select_profile.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/create_select_profile.html
@@ -11,7 +11,7 @@
 {% block requirements %}
     require(['js/entry/navigation'], function(navigation) {
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
-            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
+            {{ application.id }}, 'a, :button', '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 

--- a/wildlifelicensing/apps/applications/templates/wl/entry/enter_details.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/enter_details.html
@@ -36,7 +36,7 @@
         });
 
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
-            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
+            {{ application.id }},  'a, :button', '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 

--- a/wildlifelicensing/apps/applications/templates/wl/entry/preview.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/preview.html
@@ -25,7 +25,7 @@
         applicationPreview.setupDisclaimer($('#disclaimers').find('input[type=checkbox]'), '#lodge');
 
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
-            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
+            {{ application.id }}, 'a, :button', '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 

--- a/wildlifelicensing/apps/applications/templates/wl/entry/select_licence_type.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/select_licence_type.html
@@ -15,7 +15,7 @@
         });
 
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
-            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
+            {{ application.id }}, 'a, :button, span', '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 

--- a/wildlifelicensing/apps/applications/templates/wl/entry/upload_identification.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/upload_identification.html
@@ -11,7 +11,7 @@
 {% block requirements %}
     require(['js/entry/navigation'], function(navigation) {
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
-            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
+            {{ application.id }}, 'a, :button', '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 

--- a/wildlifelicensing/apps/applications/templates/wl/entry/upload_senior_card.html
+++ b/wildlifelicensing/apps/applications/templates/wl/entry/upload_senior_card.html
@@ -9,7 +9,7 @@
 {% block requirements %}
     require(['js/entry/navigation'], function(navigation) {
         navigation.init('Warning: any information entered into the form will be lost if not saved as draft.',
-            {{ application.id }}, '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
+            {{ application.id }}, 'a, :button', '#breadcrumbsContainer, #contentContainer', "{{ csrf_token }}");
     });
 {% endblock %}
 

--- a/wildlifelicensing/apps/applications/views/issue.py
+++ b/wildlifelicensing/apps/applications/views/issue.py
@@ -166,7 +166,7 @@ class IssueLicenceView(OfficerRequiredMixin, TemplateView):
                 if application.is_licence_amendment:
                     licence_initial_data['end_date'] = previous_licence.end_date
 
-            if not 'purpose' in licence_initial_data or len(licence_initial_data['purpose']) == 0:
+            if 'purpose' not in licence_initial_data or len(licence_initial_data['purpose']) == 0:
                 licence_initial_data['purpose'] = '\n\n'.join(Assessment.objects.filter(application=application).
                                                               values_list('purpose', flat=True))
 

--- a/wildlifelicensing/apps/applications/views/issue.py
+++ b/wildlifelicensing/apps/applications/views/issue.py
@@ -149,17 +149,33 @@ class IssueLicenceView(OfficerRequiredMixin, TemplateView):
 
             kwargs['extracted_fields'] = application.licence.extracted_fields
         else:
-            purposes = '\n\n'.join(Assessment.objects.filter(application=application).values_list('purpose', flat=True))
+            licence_initial_data = {
+                'is_renewable': application.licence_type.is_renewable,
+                'default_period': application.licence_type.default_period,
+            }
+
+            if application.previous_application is not None and application.previous_application.licence is not None:
+                previous_licence = application.previous_application.licence
+
+                licence_initial_data['regions'] = previous_licence.regions.all().values_list('pk', flat=True)
+                licence_initial_data['locations'] = previous_licence.locations
+                licence_initial_data['purpose'] = previous_licence.purpose
+                licence_initial_data['additional_information'] = previous_licence.additional_information
+                licence_initial_data['cover_letter_message'] = previous_licence.cover_letter_message
+
+                if application.is_licence_amendment:
+                    licence_initial_data['end_date'] = previous_licence.end_date
+
+            if not 'purpose' in licence_initial_data or len(licence_initial_data['purpose']) == 0:
+                licence_initial_data['purpose'] = '\n\n'.join(Assessment.objects.filter(application=application).
+                                                              values_list('purpose', flat=True))
 
             if hasattr(application.licence_type, 'returntype'):
-                return_frequency = application.licence_type.returntype.month_frequency
+                licence_initial_data['return_frequency'] = application.licence_type.returntype.month_frequency
             else:
-                return_frequency = -1
+                licence_initial_data['return_frequency'] = -1
 
-            kwargs['issue_licence_form'] = IssueLicenceForm(purpose=purposes,
-                                                            is_renewable=application.licence_type.is_renewable,
-                                                            default_period=application.licence_type.default_period,
-                                                            return_frequency=return_frequency)
+            kwargs['issue_licence_form'] = IssueLicenceForm(**licence_initial_data)
 
             kwargs['extracted_fields'] = extract_licence_fields(application.licence_type.application_schema,
                                                                 application.data)
@@ -276,6 +292,7 @@ class PreviewLicenceView(OfficerRequiredMixin, View):
 
         if issue_licence_form.is_valid():
             licence = issue_licence_form.save(commit=False)
+            licence.issue_date = date.today()
             licence.licence_type = application.licence_type
             licence.profile = application.applicant_profile
             licence.holder = application.applicant

--- a/wildlifelicensing/apps/applications/views/issue.py
+++ b/wildlifelicensing/apps/applications/views/issue.py
@@ -1,4 +1,6 @@
 import re
+from datetime import date
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.staticfiles.templatetags.staticfiles import static
@@ -64,6 +66,8 @@ class IssueLicenceView(OfficerRequiredMixin, TemplateView):
         original_issue_date = application.licence.issue_date if application.licence.is_issued else None
 
         licence.licence_sequence += 1
+
+        licence.issue_date = date.today()
 
         # reset renewal_sent flag in case of reissue
         licence.renewal_sent = False
@@ -219,7 +223,7 @@ class IssueLicenceView(OfficerRequiredMixin, TemplateView):
             application.save()
 
             if is_save:
-                messages.success(request, 'Licence saved but not yet issued.')
+                messages.warning(request, 'Licence saved but not yet issued.')
 
                 return render(request, self.template_name, {
                     'application': serialize(application, posthook=format_application),

--- a/wildlifelicensing/apps/dashboard/views/officer.py
+++ b/wildlifelicensing/apps/dashboard/views/officer.py
@@ -720,6 +720,9 @@ class DataTableLicencesOfficerView(OfficerRequiredMixin, base.DataTableBaseView)
 
     @staticmethod
     def _render_status(instance):
+        if not instance.is_issued:
+            return 'Unissued'
+
         try:
             application = Application.objects.get(licence=instance)
             replacing_application = Application.objects.get(previous_application=application)
@@ -747,6 +750,9 @@ class DataTableLicencesOfficerView(OfficerRequiredMixin, base.DataTableBaseView)
                 return 'N/A'
         except Application.DoesNotExist:
             pass
+
+        if not instance.is_issued:
+            return '<a href="{0}">Issue</a>'.format(reverse('wl_applications:issue_licence', args=(application.pk,)))
 
         reissue_url = reverse('wl_applications:reissue_licence', args=(instance.pk,))
         expiry_days = (instance.end_date - datetime.date.today()).days

--- a/wildlifelicensing/apps/dashboard/views/officer.py
+++ b/wildlifelicensing/apps/dashboard/views/officer.py
@@ -322,7 +322,7 @@ class DataTableApplicationsOfficerView(OfficerRequiredMixin, base.DataTableAppli
             )
 
     def get_initial_queryset(self):
-        return Application.objects.exclude(processing_status__in=['draft', 'temp'])
+        return Application.objects.exclude(processing_status__in=['draft', 'temp']).exclude(customer_status='temp')
 
 
 class TablesOfficerOnBehalfView(OfficerRequiredMixin, base.TablesBaseView):

--- a/wildlifelicensing/apps/main/forms.py
+++ b/wildlifelicensing/apps/main/forms.py
@@ -131,6 +131,13 @@ class IssueLicenceForm(forms.ModelForm):
 
             self.fields['return_frequency'].initial = return_frequency
 
+    def clean_start_date(self):
+        start_date = self.cleaned_data['start_date']
+        if start_date < date.today():
+            raise forms.ValidationError('Start date cannot before current date')
+
+        return start_date
+
     def clean(self):
         cleaned_data = super(IssueLicenceForm, self).clean()
 
@@ -139,8 +146,6 @@ class IssueLicenceForm(forms.ModelForm):
         if end_date is not None and start_date is not None and end_date < start_date:
             msg = 'End date must be greater than start date'
             self.add_error('end_date', msg)
-
-        return cleaned_data
 
 
 class CommunicationsLogEntryForm(forms.ModelForm):

--- a/wildlifelicensing/apps/main/forms.py
+++ b/wildlifelicensing/apps/main/forms.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import datetime
+from datetime import date
 
 from django.utils import six
 from django import forms
@@ -74,9 +74,8 @@ class IssueLicenceForm(forms.ModelForm):
 
     class Meta:
         model = WildlifeLicence
-        fields = ['issue_date', 'start_date', 'end_date', 'is_renewable', 'return_frequency', 'regions', 'purpose',
-                  'locations',
-                  'additional_information', 'cover_letter_message']
+        fields = ['start_date', 'end_date', 'is_renewable', 'return_frequency', 'regions', 'purpose',
+                  'locations', 'additional_information', 'cover_letter_message']
         widgets = {
             'regions': SelectMultiple(
                 attrs={"class": "hidden"}
@@ -105,7 +104,7 @@ class IssueLicenceForm(forms.ModelForm):
                 field.required = False
         else:
             # enforce required for some fields not required at the ledger (Licence) model level
-            required = ['issue_date', 'start_date', 'end_date']
+            required = ['start_date', 'end_date']
             for field_name in required:
                 field = self.fields.get(field_name)
                 if field is not None:
@@ -119,11 +118,9 @@ class IssueLicenceForm(forms.ModelForm):
         # if a licence instance has not been passed in nor any POST data
         # (i.e. this is creating the 'get' version of the form)
         if 'instance' not in kwargs and len(args) == 0:
-            today_date = datetime.now()
-            self.fields['issue_date'].initial = today_date.strftime(DATE_FORMAT)
-            self.fields['start_date'].initial = today_date.strftime(DATE_FORMAT)
+            today_date = date.today()
 
-            self.fields['issue_date'].localize = False
+            self.fields['start_date'].initial = today_date.strftime(DATE_FORMAT)
 
             if default_period is not None:
                 end_date = today_date + relativedelta(days=default_period)
@@ -142,6 +139,8 @@ class IssueLicenceForm(forms.ModelForm):
         if end_date is not None and start_date is not None and end_date < start_date:
             msg = 'End date must be greater than start date'
             self.add_error('end_date', msg)
+
+        return cleaned_data
 
 
 class CommunicationsLogEntryForm(forms.ModelForm):

--- a/wildlifelicensing/apps/main/forms.py
+++ b/wildlifelicensing/apps/main/forms.py
@@ -135,13 +135,6 @@ class IssueLicenceForm(forms.ModelForm):
             self.fields['additional_information'].initial = additional_information
             self.fields['cover_letter_message'].initial = cover_letter_message
 
-    def clean_start_date(self):
-        start_date = self.cleaned_data['start_date']
-        if start_date < date.today():
-            raise forms.ValidationError('Start date cannot before current date')
-
-        return start_date
-
     def clean(self):
         cleaned_data = super(IssueLicenceForm, self).clean()
 

--- a/wildlifelicensing/apps/main/forms.py
+++ b/wildlifelicensing/apps/main/forms.py
@@ -9,7 +9,7 @@ from django.forms.widgets import SelectMultiple
 
 from dateutil.relativedelta import relativedelta
 
-from wildlifelicensing.apps.main.models import WildlifeLicence, CommunicationsLogEntry
+from wildlifelicensing.apps.main.models import WildlifeLicence, Region, CommunicationsLogEntry
 
 DATE_FORMAT = '%d/%m/%Y'
 
@@ -87,13 +87,15 @@ class IssueLicenceForm(forms.ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
-        purpose = kwargs.pop('purpose', None)
-
+        regions = kwargs.pop('regions', Region.objects.none())
+        end_date = kwargs.pop('end_date', None)
         is_renewable = kwargs.pop('is_renewable', False)
-
         default_period = kwargs.pop('default_period', None)
-
         return_frequency = kwargs.pop('return_frequency', WildlifeLicence.DEFAULT_FREQUENCY)
+        locations = kwargs.pop('locations', '')
+        purpose = kwargs.pop('purpose', '')
+        additional_information = kwargs.pop('additional_information', '')
+        cover_letter_message = kwargs.pop('cover_letter_message', '')
 
         skip_required = kwargs.pop('skip_required', False)
 
@@ -110,26 +112,28 @@ class IssueLicenceForm(forms.ModelForm):
                 if field is not None:
                     field.required = True
 
-        if purpose is not None:
-            self.fields['purpose'].initial = purpose
-
         self.fields['is_renewable'].widget = forms.CheckboxInput()
 
-        # if a licence instance has not been passed in nor any POST data
-        # (i.e. this is creating the 'get' version of the form)
+        # if a licence instance has not been passed in nor any POST data (i.e. get version of form)
         if 'instance' not in kwargs and len(args) == 0:
             today_date = date.today()
 
             self.fields['start_date'].initial = today_date.strftime(DATE_FORMAT)
 
-            if default_period is not None:
+            if end_date is not None:
+                self.fields['end_date'].initial = end_date
+            elif default_period is not None:
                 end_date = today_date + relativedelta(days=default_period)
 
                 self.fields['end_date'].initial = end_date.strftime(DATE_FORMAT)
 
+            self.fields['regions'].initial = regions
             self.fields['is_renewable'].initial = is_renewable
-
             self.fields['return_frequency'].initial = return_frequency
+            self.fields['locations'].initial = locations
+            self.fields['purpose'].initial = purpose
+            self.fields['additional_information'].initial = additional_information
+            self.fields['cover_letter_message'].initial = cover_letter_message
 
     def clean_start_date(self):
         start_date = self.cleaned_data['start_date']


### PR DESCRIPTION
Issue date not longer settable on form, this is set when the licence is issued (not when saved) and will always be set to the current date at time of issue.

Relevant initial licence field values are copied from previous licence in the case of amend/renew (excluding end_date on renewals).

An applications is_temporary property is determined only by the customer's temp status.

Applications that are temporary will not show up on any dashboard.

A licence's start date must now be no earlier than the current date.

Fixed problem with selecting a variant on select licence type causing the unexpected leave warning message / session application deletion to occur.

Licences that have been saved but not issued will now show in the dashboard as "Unissued" and the action will be "Issue", which takes them to the issue licence page.