### PR TITLE
Consolidate dashboard against exceptions

### DIFF
--- a/ledger/settings_base.py
+++ b/ledger/settings_base.py
@@ -253,7 +253,11 @@ LOGGING = {
             'handlers': ['file'],
             'level': 'INFO'
         },
-#        'oscar.checkout': {
+        'wildlifelicensing': {
+            'handlers': ['file'],
+            'level': 'INFO'
+        },
+        #        'oscar.checkout': {
 #            'handlers': ['file'],
 #            'level': 'INFO'
 #        }

--- a/wildlifelicensing/apps/dashboard/static/wl/js/dash_tables.js
+++ b/wildlifelicensing/apps/dashboard/static/wl/js/dash_tables.js
@@ -9,7 +9,7 @@ define(
         'bootstrap-datetimepicker'
     ],
     function ($, _, dt, moment) {
-        "use strict";
+        'use strict';
 
         var options,
             tableOptions = {
@@ -73,8 +73,16 @@ define(
                             // add filters to the query
                             d.filters = $(options.selectors.applicationsFilterForm).serializeArray();
                         },
+                        dataSrc: function (data) {
+                            // intercept the returned data to display (console) error if any.
+                            if (data['error']) {
+                                window.console.error('Applications error:', data['error']);
+                            }
+                            return data['data'] || [];
+                        },
                         error: function (xhr, textStatus, thrownError) {
-                            console.log("Error while loading applications data:", thrownError, textStatus, xhr.responseText, xhr.status);
+                            window.console.log('Error while loading applications data:',
+                                thrownError, textStatus, xhr.responseText, xhr.status);
                             //Stop the data table 'Processing'.
                             $(options.selectors.applicationsTable + '_processing').hide();
                         }
@@ -176,8 +184,16 @@ define(
                                 d.filters = $(options.selectors.licencesFilterForm).serializeArray();
                             }
                         },
+                        dataSrc: function (data) {
+                            // intercept the returned data to display (console) error if any.
+                            if (data['error']) {
+                                window.console.error('Licences error:', data['error']);
+                            }
+                            return data['data'] || [];
+                        },
                         error: function (xhr, textStatus, thrownError) {
-                            console.log("Error while loading licences data:", thrownError, textStatus, xhr.responseText, xhr.status);
+                            window.console.log('Error while loading licences data:',
+                                thrownError, textStatus, xhr.responseText, xhr.status);
                             //Stop the data table 'Processing'.
                             $(options.selectors.licencesTable + '_processing').hide();
                         },
@@ -306,6 +322,13 @@ define(
             var returnsTableOptions = $.extend({}, tableOptions, {
                     ajax: {
                         url: options.data.returns.ajax.url,
+                        dataSrc: function (data) {
+                            // intercept the returned data to display (console) error if any.
+                            if (data['error']) {
+                                window.console.error('Returns error:', data['error']);
+                            }
+                            return data['data'] || [];
+                        },
                         data: function (d) {
                             // add filters to the query
                             if ($(options.selectors.returnsFilterForm)) {
@@ -314,7 +337,8 @@ define(
                         },
                         error: function (xhr, textStatus, thrownError) {
                             //Stop the data table 'Processing'.
-                            console.log("Error while loading returns data:", thrownError, textStatus, xhr.responseText, xhr.status);
+                            window.console.log('Error while loading returns data:',
+                                thrownError, textStatus, xhr.responseText, xhr.status);
                             $(options.selectors.returnsTable + '_processing').hide();
                         }
                     }
@@ -413,7 +437,6 @@ define(
                 $(options.selectors.returnsAccordion).collapse('show');
             }
         }
-
 
         function setFilters(query) {
             /**
@@ -517,7 +540,7 @@ define(
                 data: {
                     'applications': {
                         ajax: {
-                            url: "/dashboard/data/applications"
+                            url: '/dashboard/data/applications'
                         },
                         'columnDefinitions': [],
                         'filters': {}

--- a/wildlifelicensing/apps/dashboard/views/officer.py
+++ b/wildlifelicensing/apps/dashboard/views/officer.py
@@ -752,7 +752,7 @@ class DataTableLicencesOfficerView(OfficerRequiredMixin, base.DataTableBaseView)
                 pk=instance.pk
             )
             logger.exception(Exception(message))
-            return 'In Process'
+            return 'Unissued'
 
     @staticmethod
     def _render_action(instance):
@@ -761,7 +761,7 @@ class DataTableLicencesOfficerView(OfficerRequiredMixin, base.DataTableBaseView)
             if Application.objects.filter(previous_application=application).exists():
                 return 'N/A'
         except Application.DoesNotExist:
-            pass
+            application = None
 
         if not instance.is_issued:
             return '<a href="{0}">Issue</a>'.format(reverse('wl_applications:issue_licence', args=(application.pk,)))
@@ -773,7 +773,7 @@ class DataTableLicencesOfficerView(OfficerRequiredMixin, base.DataTableBaseView)
         if instance.end_date is not None:
             expiry_days = (instance.end_date - datetime.date.today()).days
             if instance.is_renewable:
-                if expiry_days <= 30 and expiry_days > 0:
+                if 30 >= expiry_days > 0:
                     return '<a href="{0}">Amend</a> / <a href="{1}">Renew</a> / <a href="{2}">Reissue</a>'.\
                         format(amend_url, renew_url, reissue_url)
                 elif expiry_days <= 30:
@@ -783,13 +783,7 @@ class DataTableLicencesOfficerView(OfficerRequiredMixin, base.DataTableBaseView)
             else:
                 return 'N/A'
         else:
-            # should not happen
-            message = "The licence ref:{ref} pk:{pk} has no end date!".format(
-                ref=instance.reference,
-                pk=instance.pk
-            )
-            logger.exception(Exception(message))
-            return 'N/A'
+            return '<a href="{0}">Issue</a>'.format(reverse('wl_applications:issue_licence', args=(application.pk,)))
 
     def get_initial_queryset(self):
         return WildlifeLicence.objects.all()


### PR DESCRIPTION
* The dashboard was throwing exception if a licence has no `end_date`.  Added some guards for that.
* Added a filter to the initial licence queryset for the user: it should only see licences that has been issued (= with a reference number)
* created a log for wildlifelicensing, the 'catch-all' doesn't seem to work!