### PR TITLE
Removed the proxy column in officer's application dashboard

### DIFF
--- a/wildlifelicensing/apps/applications/templates/wl/process/process_app.html
+++ b/wildlifelicensing/apps/applications/templates/wl/process/process_app.html
@@ -109,7 +109,7 @@
                                         </div>
                                     {% endwith %}
                                     {% with proxy=data.application.proxy_applicant %}
-                                        {%  if proxy %}
+                                        {% if proxy %}
                                             <div class="row bottom-buffer-xs">
                                                 <div class="col-md-12">
                                                     <label>Proxy</label>

--- a/wildlifelicensing/apps/applications/templates/wl/process/process_app.html
+++ b/wildlifelicensing/apps/applications/templates/wl/process/process_app.html
@@ -108,6 +108,16 @@
                                             {% endif %}
                                         </div>
                                     {% endwith %}
+                                    {% with proxy=data.application.proxy_applicant %}
+                                        {%  if proxy %}
+                                            <div class="row bottom-buffer-xs">
+                                                <div class="col-md-12">
+                                                    <label>Proxy</label>
+                                                    <div>{{ proxy.first_name }} {{ proxy.last_name }}</div>
+                                                </div>
+                                            </div>
+                                        {%  endif %}
+                                    {% endwith %}
                                     <div class="row">
                                         <div class="col-md-5">
                                             <label>Lodged on</label>

--- a/wildlifelicensing/apps/dashboard/views/officer.py
+++ b/wildlifelicensing/apps/dashboard/views/officer.py
@@ -171,9 +171,6 @@ class TablesApplicationsOfficerView(OfficerRequiredMixin, base.TablesBaseView):
                 'title': 'Assignee'
             },
             {
-                'title': 'Proxy'
-            },
-            {
                 'title': 'Payment',
                 'searchable': False,
                 'orderable': False
@@ -229,7 +226,6 @@ class DataTableApplicationsOfficerView(OfficerRequiredMixin, base.DataTableAppli
         'processing_status',
         'lodgement_date',
         'assigned_officer',
-        'proxy_applicant',
         'payment',
         'application_pdf',
         'action'
@@ -242,7 +238,6 @@ class DataTableApplicationsOfficerView(OfficerRequiredMixin, base.DataTableAppli
         'processing_status',
         'lodgement_date',
         ['assigned_officer.first_name', 'assigned_officer.last_name', 'assigned_officer.email'],
-        ['proxy_applicant.first_name', 'proxy_applicant.last_name', 'proxy_applicant.email'],
         ''
         ''
     ]
@@ -261,12 +256,6 @@ class DataTableApplicationsOfficerView(OfficerRequiredMixin, base.DataTableAppli
                 search
             ),
             'render': lambda self, instance: base.render_user_name(instance.assigned_officer)
-        },
-        'proxy_applicant': {
-            'search': lambda self, search: base.build_field_query([
-                'proxy_applicant__last_name', 'proxy_applicant__first_name'],
-                search),
-            'render': lambda self, obj: base.render_user_name(obj.proxy_applicant)
         },
         'payment': {
             'render': lambda self, instance: base.render_payment(instance, self.request.build_absolute_uri(

--- a/wildlifelicensing/static/wl/css/base.css
+++ b/wildlifelicensing/static/wl/css/base.css
@@ -46,6 +46,10 @@
     margin-bottom: 20px;
 }
 
+.bottom-buffer-xs {
+    margin-bottom: 5px;
+}
+
 .left-buffer-xxxl {
     margin-left: 40px;
 }


### PR DESCRIPTION
Removed the proxy_applicant column in the officer's dashboard and add proxy details in the process page.
See comments in:  
https://kanboard.dpaw.wa.gov.au/?controller=TaskViewController&action=show&task_id=3223&project_id=24